### PR TITLE
Implemented :log_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Airbrussh.configure do |config|
   # config.truncate = false
   # Default:
   config.truncate = :auto
+
+  # By default Airbrussh mutes stdout and stderr (sending it to config.logfile)
+  # If you need (also temporary) enable stdout you can set log_level to :debug
+  # This can also be done live calling
+  # Airbrussh.configuration.log_level = :debug
+  config.log_level = :info
 end
 ```
 

--- a/lib/airbrussh/configuration.rb
+++ b/lib/airbrussh/configuration.rb
@@ -1,12 +1,13 @@
 module Airbrussh
   class Configuration
-    attr_accessor :log_file, :monkey_patch_rake, :color, :truncate
+    attr_accessor :log_file, :monkey_patch_rake, :color, :truncate, :log_level
 
     def initialize
       self.log_file = nil
       self.monkey_patch_rake = false
       self.color = :auto
       self.truncate = :auto
+      self.log_level = :info
     end
   end
 end

--- a/lib/airbrussh/formatter.rb
+++ b/lib/airbrussh/formatter.rb
@@ -120,7 +120,7 @@ module Airbrussh
           print_line "    #{status}"
         end
       elsif Airbrussh.configuration.log_level == :debug
-        command.full_stdout.split("\n").each do |line|
+        command.stdout.split("\n").each do |line|
           print_line "      #{number} #{line}"
         end
       end

--- a/lib/airbrussh/formatter.rb
+++ b/lib/airbrussh/formatter.rb
@@ -109,14 +109,20 @@ module Airbrussh
       ctx = context_for_command(command)
       number = '%02d' % ctx.number
 
-      if ctx.first_execution?
-        description = yellow(ctx.shell_string)
-        print_line "      #{number} #{description}"
-      end
+      if ctx.first_execution? || command.finished?
+        if ctx.first_execution?
+          description = yellow(ctx.shell_string)
+          print_line "      #{number} #{description}"
+        end
 
-      if command.finished?
-        status = format_command_completion_status(command, number)
-        print_line "    #{status}"
+        if command.finished?
+          status = format_command_completion_status(command, number)
+          print_line "    #{status}"
+        end
+      elsif Airbrussh.configuration.log_level == :debug
+        command.full_stdout.split("\n").each do |line|
+          print_line "      #{number} #{line}"
+        end
       end
     end
 

--- a/lib/airbrussh/formatter.rb
+++ b/lib/airbrussh/formatter.rb
@@ -120,7 +120,7 @@ module Airbrussh
           print_line "    #{status}"
         end
       elsif Airbrussh.configuration.log_level == :debug
-        command.stdout.split("\n").each do |line|
+        command.full_stdout.split("\n").each do |line|
           print_line "      #{number} #{line}"
         end
       end


### PR DESCRIPTION
As per mattbrictson/airbrussh#3, this commit adds :log_level to
Airbrussh configuration, allowing stdout to be enabled if needed.

I was also wondering if also disable `truncate` option but I guess it's better to let the decision to the user.

@mattbrictson what do you think of this solution?