### PR TITLE
Add support for config.command_output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your contribution here.
 * New `config.banner` option allows startup message to be disabled or changed (suggestion from [@justindowning](https://github.com/justindowning))
+* New `config.command_output` option gives full control of whether airbrussh shows or hides the stderr and stdout data received from remote commands; see the usage section of the README for further explanation (suggestion from [@carlesso](https://github.com/carlesso))
 
 ## 0.2.1 (2015-03-02)
 

--- a/README.md
+++ b/README.md
@@ -53,39 +53,70 @@ Airbrussh automatically replaces the default Capistrano log formatter, so there 
 ```ruby
 Airbrussh.configure do |config|
   # Capistrano's default, un-airbrusshed output is saved to a file to
-  # facilitate debugging. To disable this entirely:
+  # facilitate debugging.
+  #
+  # To disable this entirely:
   # config.log_file = nil
+  #
   # Default:
   config.log_file = "log/capistrano.log"
 
   # Airbrussh patches Rake so it can access the name of the currently executing
   # task. Set this to false if monkey patching is causing issues.
+  #
   # Default:
   config.monkey_patch_rake = true
 
   # Ansi colors will be used in the output automatically based on whether the
   # output is a TTY, or if the SSHKIT_COLOR environment variable is set.
+  #
   # To disable color always:
   # config.color = false
+  #
   # Default:
   config.color = :auto
 
   # Output is automatically truncated to the width of the terminal window, if
   # possible. If the width of the terminal can't be determined, no truncation
-  # is performed. To truncate to a fixed width:
+  # is performed.
+  #
+  # To truncate to a fixed width:
   # config.truncate = 80
+  #
   # Or to disable truncation entirely:
   # config.truncate = false
+  #
   # Default:
   config.truncate = :auto
 
   # If a log_file is configured, airbrussh will output a message at startup
-  # displaying the log_file location. To always disable this message:
+  # displaying the log_file location.
+  #
+  # To always disable this message:
   # config.banner = false
+  #
   # To display an alternative message:
   # config.banner = "Hello, world!"
+  #
   # Default:
   config.banner = :auto
+
+  # You can control whether airbrussh shows the output of SSH commands. For
+  # brevity, the output is hidden by default.
+  #
+  # Display stdout of SSH commands. Stderr is not displayed.
+  # config.command_output = :stdout
+  #
+  # Display stderr of SSH commands. Stdout is not displayed.
+  # config.command_output = :stderr
+  #
+  # Display all SSH command output.
+  # config.command_output = [:stdout, :stderr]
+  # or
+  # config.command_output = true
+  #
+  # Default (all output suppressed):
+  config.command_output = false
 end
 ```
 
@@ -107,6 +138,7 @@ Airbrussh.configure do |config|
   config.color = :auto
   config.truncate = :auto
   config.banner = :auto
+  config.command_output = false
 end
 ```
 

--- a/lib/airbrussh/configuration.rb
+++ b/lib/airbrussh/configuration.rb
@@ -1,6 +1,7 @@
 module Airbrussh
   class Configuration
-    attr_accessor :log_file, :monkey_patch_rake, :color, :truncate, :banner
+    attr_accessor :log_file, :monkey_patch_rake, :color, :truncate, :banner,
+                  :command_output
 
     def initialize
       self.log_file = nil
@@ -8,6 +9,21 @@ module Airbrussh
       self.color = :auto
       self.truncate = :auto
       self.banner = :auto
+      self.command_output = false
+    end
+
+    def command_output_stdout?
+      command_output_include?(:stdout)
+    end
+
+    def command_output_stderr?
+      command_output_include?(:stderr)
+    end
+
+    private
+
+    def command_output_include?(sym)
+      command_output == true || Array(command_output).include?(sym)
     end
   end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,0 +1,48 @@
+require "minitest_helper"
+
+class TestConfiguration < Minitest::Test
+  def setup
+    # Reset any configuration changes done by the tests
+    Airbrussh.reset
+  end
+
+  def test_default_command_output
+    refute(config.command_output)
+  end
+
+  def test_effects_of_command_output_true
+    config.command_output = true
+    assert(config.command_output_stdout?)
+    assert(config.command_output_stderr?)
+  end
+
+  def test_effects_of_command_output_false
+    config.command_output = false
+    refute(config.command_output_stdout?)
+    refute(config.command_output_stderr?)
+  end
+
+  def test_effects_of_command_output_stdout
+    config.command_output = :stdout
+    assert(config.command_output_stdout?)
+    refute(config.command_output_stderr?)
+  end
+
+  def test_effects_of_command_output_stderr
+    config.command_output = :stderr
+    refute(config.command_output_stdout?)
+    assert(config.command_output_stderr?)
+  end
+
+  def test_effects_of_command_output_stdout_stderr
+    config.command_output = [:stdout, :stderr]
+    assert(config.command_output_stdout?)
+    assert(config.command_output_stderr?)
+  end
+
+  private
+
+  def config
+    Airbrussh.configuration
+  end
+end


### PR DESCRIPTION
Normally airbrussh hides all stderr and stdout data returned by SSH commands. With this commit, users of airbrussh can selectively enable displaying of stderr and/or stdout data.

Addesses #3 

@carlesso can you review?