### PR TITLE
Move rake-specific data and logic out of formatter

### DIFF
--- a/lib/airbrussh/formatter.rb
+++ b/lib/airbrussh/formatter.rb
@@ -122,14 +122,10 @@ module Airbrussh
       return if debug?(command)
       print_task_if_changed
 
-      if first_execution?(command)
+      if command.first_execution?
         shell_string = shell_string(command)
         print_line "      #{command_number(command)} #{yellow(shell_string)}"
       end
-    end
-
-    def first_execution?(command)
-      command.first_execution?
     end
 
     # Prints the data from the stdout and stderr streams of the given command,

--- a/lib/airbrussh/rake/command.rb
+++ b/lib/airbrussh/rake/command.rb
@@ -1,0 +1,24 @@
+module Airbrussh
+  module Rake
+    # Decorates an SSHKit Command to add Rake-specific contextual information:
+    #
+    # * first_execution? - is this the first time this command has been run in
+    #                      the context of the current rake task?
+    # * position - zero-based position of this command in the list of
+    #              all commands that have been run in the current rake task
+    #
+    class Command < SimpleDelegator
+      attr_reader :first_execution, :position
+
+      def initialize(command, first_execution, position)
+        super(command)
+        @first_execution = first_execution
+        @position = position
+      end
+
+      def first_execution?
+        first_execution
+      end
+    end
+  end
+end

--- a/lib/airbrussh/rake/context.rb
+++ b/lib/airbrussh/rake/context.rb
@@ -1,0 +1,73 @@
+require "rake"
+require "airbrussh/rake/command"
+
+module Airbrussh
+  module Rake
+    # Maintains information about what Rake task is currently being invoked,
+    # in order to be able to decorate SSHKit commands with additional
+    # context-sensitive information. Works via a monkey patch to Rake::Task,
+    # which can be disabled via by setting
+    # Airbrussh.configuration.monkey_patch_rake = false.
+    #
+    class Context
+      def initialize(config=Airbrussh.configuration)
+        @history = []
+        @enabled = config.monkey_patch_rake
+        self.class.install_monkey_patch if enabled?
+      end
+
+      # Returns the name of the currently-executing rake task, if it can be
+      # determined. If monkey patching is disabled, this will be nil.
+      def current_task_name
+        return nil unless enabled?
+        self.class.current_task_name
+      end
+
+      # Decorate an SSHKit Command with Rake::Command to provide additional
+      # context-sensitive information.
+      def decorate_command(command)
+        reset_history_if_task_changed
+
+        first_execution = !history.include?(command.to_s)
+        history << command.to_s
+        history.uniq!
+
+        Airbrussh::Rake::Command.new(
+          command,
+          first_execution,
+          history.index(command.to_s)
+        )
+      end
+
+      class << self
+        attr_accessor :current_task_name
+
+        def install_monkey_patch
+          return if ::Rake::Task.instance_methods.include?(:_airbrussh_execute)
+
+          ::Rake::Task.class_exec do
+            alias_method :_airbrussh_execute, :execute
+            def execute(args=nil) # rubocop:disable Lint/NestedMethodDefinition
+              ::Airbrussh::Rake::Context.current_task_name = name.to_s
+              _airbrussh_execute(args)
+            end
+          end
+        end
+      end
+
+      private
+
+      attr_reader :history
+      attr_accessor :last_task_name
+
+      def reset_history_if_task_changed
+        history.clear if last_task_name != current_task_name
+        self.last_task_name = current_task_name
+      end
+
+      def enabled?
+        @enabled
+      end
+    end
+  end
+end

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -9,6 +9,7 @@ class Airbrussh::FormatterTest < Minitest::Test
     @user = "test_user"
     @log_file = StringIO.new
     @config = Airbrussh::Configuration.new
+    @config.monkey_patch_rake = true
     @config.command_output = true
     @config.log_file = @log_file
 
@@ -16,7 +17,7 @@ class Airbrussh::FormatterTest < Minitest::Test
   end
 
   def teardown
-    Airbrussh::Formatter.current_rake_task = nil
+    Airbrussh::Rake::Context.current_task_name = nil
     SSHKit.reset_configuration!
   end
 
@@ -171,12 +172,12 @@ class Airbrussh::FormatterTest < Minitest::Test
 
   def test_handles_rake_tasks
     on_local do
-      Airbrussh::Formatter.current_rake_task = "deploy"
-      Airbrussh::Formatter.current_rake_task = "deploy_dep1"
+      Airbrussh::Rake::Context.current_task_name = "deploy"
+      Airbrussh::Rake::Context.current_task_name = "deploy_dep1"
       execute(:echo, "command 1")
       info("Starting command 2")
       execute(:echo, "command 2")
-      Airbrussh::Formatter.current_rake_task = "deploy_dep2"
+      Airbrussh::Rake::Context.current_task_name = "deploy_dep2"
       execute(:echo, "command 3")
       execute(:echo, "command 4")
       warn("All done")

--- a/test/airbrussh/rake/command_test.rb
+++ b/test/airbrussh/rake/command_test.rb
@@ -1,0 +1,19 @@
+require "minitest_helper"
+require "airbrussh/rake/command"
+
+class Airbrussh::Rake::CommandTest < Minitest::Test
+  def setup
+    original = %w(foo bar)
+    @command = Airbrussh::Rake::Command.new(original, true, 1)
+  end
+
+  def test_delegates_to_original_object
+    assert_equal("foo", @command.first)
+    assert_equal("bar", @command.last)
+  end
+
+  def test_contextual_data
+    assert(@command.first_execution?)
+    assert_equal(1, @command.position)
+  end
+end

--- a/test/airbrussh/rake/context_test.rb
+++ b/test/airbrussh/rake/context_test.rb
@@ -1,0 +1,71 @@
+require "minitest_helper"
+require "airbrussh/rake/context"
+
+class Airbrussh::Rake::ContextTest < Minitest::Test
+  def setup
+    @app = Rake::Application.new
+    @config = Airbrussh::Configuration.new
+  end
+
+  def teardown
+    Airbrussh::Rake::Context.current_task_name = nil
+  end
+
+  def test_current_task_name_is_nil_when_disabled
+    @config.monkey_patch_rake = false
+    context = Airbrussh::Rake::Context.new(@config)
+    define_and_invoke_rake_task("one") do
+      assert_nil(context.current_task_name)
+    end
+  end
+
+  def test_current_task_name
+    @config.monkey_patch_rake = true
+    context = Airbrussh::Rake::Context.new(@config)
+
+    assert_nil(context.current_task_name)
+
+    define_and_invoke_rake_task("one") do
+      assert_equal("one", context.current_task_name)
+    end
+
+    define_and_invoke_rake_task("two") do
+      assert_equal("two", context.current_task_name)
+    end
+  end
+
+  def test_decorate_command
+    @config.monkey_patch_rake = true
+    context = Airbrussh::Rake::Context.new(@config)
+
+    define_and_invoke_rake_task("one") do
+      context.decorate_command(:command_one)
+      command_one = context.decorate_command(:command_one)
+      context.decorate_command(:command_two)
+      command_two = context.decorate_command(:command_two)
+
+      assert_equal(0, command_one.position)
+      assert_equal(1, command_two.position)
+      refute(command_one.first_execution?)
+      refute(command_two.first_execution?)
+    end
+
+    define_and_invoke_rake_task("two") do
+      command_three = context.decorate_command(:command_three)
+      command_four = context.decorate_command(:command_four)
+
+      assert_equal(0, command_three.position)
+      assert_equal(1, command_four.position)
+      assert(command_three.first_execution?)
+      assert(command_four.first_execution?)
+    end
+  end
+
+  private
+
+  def define_and_invoke_rake_task(name, &block)
+    task = Rake::Task.new(name, @app)
+    task.enhance(&block)
+    task.invoke
+  end
+end


### PR DESCRIPTION
This PR introduces `Airbrussh::Rake::Context` and `Airbrussh::Rake::Command`, which:

* take care of tracking rake information (current task, execution order of commands); and
* expose this data via a decorator that wraps `SSHKit::Command`

This simplifies `Airbrussh::Formatter` somewhat, as now it can simply ask:

```ruby
command.first_execution?
command.position
```

Formatter tests are still green, with only some minor tweaks to `setup`. The new rake-related classes have full test coverage.

With these changes, `Formatter` now passes RuboCop's class length check.

@robd Do these changes make sense to you? I plan on doing another, similar refactor to pull out some of the formatting logic into a separate class.