### PR TITLE
Consoliate command formatting helper methods in CommandFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ Airbrussh is in a pre-1.0 state. This means that its APIs and behavior are subje
 
 * Your contribution here!
 * Added Rubocop enforcement to Travis
-* Airbrussh now has decent test coverage, and is tested by Travis against a matrix of Ruby and SSHKit versions ([@robd](https://github.com/robd))
+* Added Code Climate and Coveralls checks (see badges in the README)
+* Airbrussh now has good test coverage, and is tested by Travis against a matrix of Ruby and SSHKit versions ([@robd](https://github.com/robd))
 * Changes to support the new SSHKit formatter API, as introduced in [SSHKit #257](https://github.com/capistrano/sshkit/pull/257) ([@robd](https://github.com/robd))
 * `Airbrussh.reset` has been removed
+* Airbrussh now has its own ANSI color code; it no longer relies on a third-party gem (i.e. `colorize`)
 
 ## [0.4.1][] (2015-05-06)
 

--- a/lib/airbrussh/capistrano.rb
+++ b/lib/airbrussh/capistrano.rb
@@ -1,5 +1,5 @@
 require "airbrussh"
-require "colorize"
+require "airbrussh/colors"
 require "sshkit/formatter/airbrussh"
 
 # airbrush/capistrano uses a different default configuration
@@ -10,12 +10,12 @@ end
 
 # Sanity check!
 unless defined?(Capistrano) && defined?(:namespace)
-  $stderr.puts\
-    "WARNING: airbrussh/capistrano must be loaded by Capistrano in order "\
-    "to work.\n"\
-    "Require this gem within your application's Capfile, as described here:\n"\
-    "https://github.com/mattbrictson/airbrussh#installation"\
-    .colorize(:red)
+  $stderr.puts(
+    Airbrussh::Colors.red(
+      "WARNING: airbrussh/capistrano must be loaded by Capistrano in order "\
+      "to work.\nRequire this gem within your application's Capfile, as "\
+      "described here:\nhttps://github.com/mattbrictson/airbrussh#installation"
+    ))
 end
 
 # Hook into Capistrano's init process to set the formatter

--- a/lib/airbrussh/colors.rb
+++ b/lib/airbrussh/colors.rb
@@ -10,7 +10,7 @@ module Airbrussh
       :gray   => 90
     }.freeze
 
-    private
+    module_function
 
     # Define red, green, blue, etc. methods that return a copy of the
     # String that is wrapped in the corresponding ANSI color escape

--- a/lib/airbrussh/colors.rb
+++ b/lib/airbrussh/colors.rb
@@ -1,0 +1,24 @@
+module Airbrussh
+  # Very basic support for ANSI color, so that we don't have to rely on
+  # any external dependencies.
+  module Colors
+    ANSI_CODES = {
+      :red    => 31,
+      :green  => 32,
+      :yellow => 33,
+      :blue   => 34,
+      :gray   => 90
+    }.freeze
+
+    private
+
+    # Define red, green, blue, etc. methods that return a copy of the
+    # String that is wrapped in the corresponding ANSI color escape
+    # sequence.
+    ANSI_CODES.each do |name, code|
+      define_method(name) do |string|
+        "\e[0;#{code};49m#{string}\e[0m"
+      end
+    end
+  end
+end

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "airbrussh/colors"
 # rubocop:disable Style/AsciiComments
 

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -1,0 +1,76 @@
+require "airbrussh/colors"
+# rubocop:disable Style/AsciiComments
+
+module Airbrussh
+  # Decorates an SSHKit::Command to add string output helpers.
+  class CommandFormatter < SimpleDelegator
+    include Airbrussh::Colors
+
+    # Prefixes the line with the command number and removes the newline.
+    #
+    # format_output("hello\n") # => "01 hello"
+    #
+    def format_output(line)
+      "#{number} #{line.chomp}"
+    end
+
+    # Returns the abbreviated command (in yellow) with the number prefix.
+    #
+    # start_message # => "01 echo hello"
+    #
+    def start_message
+      "#{number} #{yellow(abbreviated)}"
+    end
+
+    # Returns a green (success) or red (failure) message depending on the
+    # exit status.
+    #
+    # exit_message # => "✔ 01 user@host 0.084s"
+    # exit_message # => "✘ 01 user@host 0.084s"
+    #
+    # If `log_file` is specified, it is appended to the message
+    # in the failure case.
+    #
+    # exit_message("out.log")
+    # # => "✘ 01 user@host (see out.log for details) 0.084s"
+    #
+    def exit_message(log_file=nil)
+      if failure?
+        message = red(failure_message(log_file))
+      else
+        message = green(success_message)
+      end
+      message << " #{gray(runtime)}"
+    end
+
+    private
+
+    def user_at_host
+      user_str = user { host.user }
+      host_str = host.to_s
+      [user_str, host_str].join("@")
+    end
+
+    def runtime
+      format("%5.3fs", super)
+    end
+
+    def abbreviated
+      to_s.sub(%r{^/usr/bin/env }, "")
+    end
+
+    def number
+      format("%02d", position + 1)
+    end
+
+    def success_message
+      "✔ #{number} #{user_at_host}"
+    end
+
+    def failure_message(log_file)
+      message = "✘ #{number} #{user_at_host}"
+      message << " (see #{log_file} for details)" if log_file
+      message
+    end
+  end
+end

--- a/lib/airbrussh/formatter.rb
+++ b/lib/airbrussh/formatter.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require "airbrussh/colors"
 require "airbrussh/command_formatter"
 require "airbrussh/command_output"

--- a/test/airbrussh/colors_test.rb
+++ b/test/airbrussh/colors_test.rb
@@ -1,0 +1,26 @@
+require "minitest_helper"
+require "airbrussh/colors"
+
+class Airbrussh::ColorsTest < Minitest::Test
+  include Airbrussh::Colors
+
+  def test_red
+    assert_equal("\e[0;31;49mhello\e[0m", red("hello"))
+  end
+
+  def test_green
+    assert_equal("\e[0;32;49mhello\e[0m", green("hello"))
+  end
+
+  def test_yellow
+    assert_equal("\e[0;33;49mhello\e[0m", yellow("hello"))
+  end
+
+  def test_blue
+    assert_equal("\e[0;34;49mhello\e[0m", blue("hello"))
+  end
+
+  def test_gray
+    assert_equal("\e[0;90;49mhello\e[0m", gray("hello"))
+  end
+end

--- a/test/airbrussh/command_formatter_test.rb
+++ b/test/airbrussh/command_formatter_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "minitest_helper"
 require "ostruct"
 require "airbrussh/command_formatter"

--- a/test/airbrussh/command_formatter_test.rb
+++ b/test/airbrussh/command_formatter_test.rb
@@ -1,0 +1,42 @@
+require "minitest_helper"
+require "ostruct"
+require "airbrussh/command_formatter"
+
+class Airbrussh::CommandFormatterTest < Minitest::Test
+  def setup
+    sshkit_command = OpenStruct.new(
+      :host => "12.34.56.78",
+      :user => "deployer",
+      :runtime => 1.23456,
+      :position => 0,
+      :failure? => false
+    )
+    def sshkit_command.to_s
+      "/usr/bin/env echo hello"
+    end
+    @command = Airbrussh::CommandFormatter.new(sshkit_command)
+  end
+
+  def test_format_output
+    assert_equal("01 hello", @command.format_output("hello\n"))
+  end
+
+  def test_start_message
+    assert_equal("01 \e[0;33;49mecho hello\e[0m", @command.start_message)
+  end
+
+  def test_exit_message_success
+    assert_equal(
+      "\e[0;32;49m✔ 01 deployer@12.34.56.78\e[0m \e[0;90;49m1.235s\e[0m",
+      @command.exit_message)
+  end
+
+  def test_exit_message_failure
+    @command.stub(:failure?, true) do
+      assert_equal(
+        "\e[0;31;49m✘ 01 deployer@12.34.56.78 (see out.log for details)\e[0m "\
+        "\e[0;90;49m1.235s\e[0m",
+        @command.exit_message("out.log"))
+    end
+  end
+end


### PR DESCRIPTION
This PR builds upon #21 and introduces the `Airbrussh::CommandFormatter` class. This is a decorator (using Ruby's `SimpleDelegator`) that wraps an `SSHKit::Command` to add various formatting helpers.

This consolidates all the command-specific formatting logic in one place. Since CommandFormatter is just a bunch of simple string manipulations, it is also very easy to test.

Along the way I also added `Airbrussh::Colors`, which is a very basic implementation of the ANSI color logic we need for Airbrussh, with no external dependencies. This replaces our (undeclared) dependency on the `colorize` gem.