### PR TITLE
Test rake integration

### DIFF
--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -4,6 +4,8 @@ require "minitest_helper"
 # rubocop:disable Metrics/LineLength
 
 class Airbrussh::FormatterTest < Minitest::Test
+  include RakeTaskDefinition
+
   def setup
     @output = StringIO.new
     @log_file = StringIO.new
@@ -279,18 +281,13 @@ class Airbrussh::FormatterTest < Minitest::Test
   private
 
   def on_local(task_name=nil, &block)
-    Rake::Task.define_task(task_name || self.class.unique_task_name) do
+    define_and_execute_rake_task(task_name) do
       local_backend = SSHKit::Backend::Local.new(&block)
       # Note: The Local backend default log changed to include the user name around version 1.7.1
       # Therefore we inject a user in order to make the logging consistent in old versions (i.e. 1.6.1)
       local_backend.instance_variable_get(:@host).user = @user
       local_backend.run
-    end.execute
-  end
-
-  def self.unique_task_name
-    @task_index ||= 0
-    "#{name}_#{@task_index += 1}"
+    end
   end
 
   def assert_output_lines(*expected_output)

--- a/test/airbrussh/rake/context_test.rb
+++ b/test/airbrussh/rake/context_test.rb
@@ -2,8 +2,9 @@ require "minitest_helper"
 require "airbrussh/rake/context"
 
 class Airbrussh::Rake::ContextTest < Minitest::Test
+  include RakeTaskDefinition
+
   def setup
-    @app = Rake::Application.new
     @config = Airbrussh::Configuration.new
   end
 
@@ -14,7 +15,7 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
   def test_current_task_name_is_nil_when_disabled
     @config.monkey_patch_rake = false
     context = Airbrussh::Rake::Context.new(@config)
-    define_and_invoke_rake_task("one") do
+    define_and_execute_rake_task("one") do
       assert_nil(context.current_task_name)
     end
   end
@@ -25,11 +26,11 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
 
     assert_nil(context.current_task_name)
 
-    define_and_invoke_rake_task("one") do
+    define_and_execute_rake_task("one") do
       assert_equal("one", context.current_task_name)
     end
 
-    define_and_invoke_rake_task("two") do
+    define_and_execute_rake_task("two") do
       assert_equal("two", context.current_task_name)
     end
   end
@@ -38,7 +39,7 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
     @config.monkey_patch_rake = true
     context = Airbrussh::Rake::Context.new(@config)
 
-    define_and_invoke_rake_task("one") do
+    define_and_execute_rake_task("one") do
       context.decorate_command(:command_one)
       command_one = context.decorate_command(:command_one)
       context.decorate_command(:command_two)
@@ -50,7 +51,7 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
       refute(command_two.first_execution?)
     end
 
-    define_and_invoke_rake_task("two") do
+    define_and_execute_rake_task("two") do
       command_three = context.decorate_command(:command_three)
       command_four = context.decorate_command(:command_four)
 
@@ -59,13 +60,5 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
       assert(command_three.first_execution?)
       assert(command_four.first_execution?)
     end
-  end
-
-  private
-
-  def define_and_invoke_rake_task(name, &block)
-    task = Rake::Task.new(name, @app)
-    task.enhance(&block)
-    task.invoke
   end
 end

--- a/test/support/rake_task_definition.rb
+++ b/test/support/rake_task_definition.rb
@@ -1,0 +1,11 @@
+module RakeTaskDefinition
+  def define_and_execute_rake_task(task_name, &block)
+    task_name ||= RakeTaskDefinition.unique_task_name(name)
+    Rake::Task.define_task(task_name, &block).execute
+  end
+
+  def self.unique_task_name(test_name)
+    @task_index ||= 0
+    "#{test_name}_#{@task_index += 1}"
+  end
+end


### PR DESCRIPTION
This PR adds coverage for the rake monkey patching to the formatter test as per #23.

I didn't extract a mixin for the rake task definition / execution, because I wanted to discuss first. I used `Rake::Task.define_task(block).execute` as opposed to:

```ruby
task = Rake::Task.new(name, @app)
task.enhance(&block)
task.invoke
```

I'm not sure whether there is any significant difference between the two, but `define_task` seems to have the advantage that you don't have to create a `Rake::Application`. But perhaps defining the `@app` every test run is preferable if it means the tasks are only defined local to that app and there is no pollution across tests?

I think `execute` is slightly preferable to `invoke`, because it will always run the task even if we define a duplicate accidentally within a test. This would be silently ignored with `invoke`.

I added a default rake task name based on the test name and an increasing globally index. I think this removes noise in the tests - you only need to define a task name if you need to assert on it later.

@mattbrictson Let me know what you think when convenient.


