### PR TITLE
Add tests for airbrussh/capistrano

### DIFF
--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"
+  spec.add_development_dependency "mocha"
   spec.add_development_dependency "rubocop", ">= 0.31.0"
 end

--- a/lib/airbrussh/capistrano.rb
+++ b/lib/airbrussh/capistrano.rb
@@ -41,6 +41,6 @@ namespace :deploy do
         "** Refer to #{log_file} for details. Here are the last 20 lines:"
       ))
     err.print_line
-    system("tail -n 20 #{log_file.shellescape} 1>&2")
+    err.write(`tail -n 20 #{log_file.shellescape} 2>&1`)
   end
 end

--- a/lib/airbrussh/colors.rb
+++ b/lib/airbrussh/colors.rb
@@ -10,8 +10,6 @@ module Airbrussh
       :gray   => 90
     }.freeze
 
-    module_function
-
     # Define red, green, blue, etc. methods that return a copy of the
     # String that is wrapped in the corresponding ANSI color escape
     # sequence.
@@ -19,6 +17,7 @@ module Airbrussh
       define_method(name) do |string|
         "\e[0;#{code};49m#{string}\e[0m"
       end
+      module_function(name)
     end
   end
 end

--- a/test/airbrussh/capistrano_test.rb
+++ b/test/airbrussh/capistrano_test.rb
@@ -27,8 +27,9 @@ class Airbrussh::CapistranoTest < Minitest::Test
   end
 
   def teardown
-    Rake::Task.clear
     $stderr = @stderr_orig
+    Rake::Task.clear
+    Airbrussh::Rake::Context.current_task_name = nil
   end
 
   def test_configures_for_capistrano

--- a/test/airbrussh/capistrano_test.rb
+++ b/test/airbrussh/capistrano_test.rb
@@ -20,7 +20,6 @@ include Capistrano::MockDSL
 
 class Airbrussh::CapistranoTest < Minitest::Test
   def setup
-    Rake::Task.clear
     load(File.expand_path("../../../lib/airbrussh/capistrano.rb", __FILE__))
     @stderr_orig = $stderr
     @stderr = StringIO.new
@@ -28,6 +27,7 @@ class Airbrussh::CapistranoTest < Minitest::Test
   end
 
   def teardown
+    Rake::Task.clear
     $stderr = @stderr_orig
   end
 

--- a/test/airbrussh/capistrano_test.rb
+++ b/test/airbrussh/capistrano_test.rb
@@ -52,7 +52,7 @@ class Airbrussh::CapistranoTest < Minitest::Test
   end
 
   def test_prints_last_20_logfile_lines_on_deploy_failure
-    log_file = Tempfile.create("airbrussh-test-")
+    log_file = Tempfile.new("airbrussh-test-")
     begin
       log_file.write((11..31).map { |i| "line #{i}\n" }.join)
       log_file.close
@@ -64,7 +64,7 @@ class Airbrussh::CapistranoTest < Minitest::Test
       refute_match("line 11", stderr)
       (12..31).each { |i| assert_match("line #{i}", stderr) }
     ensure
-      File.unlink(log_file.path)
+      log_file.unlink
     end
   end
 

--- a/test/airbrussh/capistrano_test.rb
+++ b/test/airbrussh/capistrano_test.rb
@@ -1,0 +1,82 @@
+require "minitest_helper"
+require "rake"
+require "stringio"
+require "tempfile"
+
+# Capistrano needs to be defined in order for airbrussh/capistrano to load,
+# and it also expects there to be a `set` method.
+module Capistrano
+  module MockDSL
+    class << self
+      attr_accessor :set_args
+    end
+
+    def set(*args)
+      Capistrano::MockDSL.set_args = args
+    end
+  end
+end
+include Capistrano::MockDSL
+
+class Airbrussh::CapistranoTest < Minitest::Test
+  def setup
+    Rake::Task.clear
+    load(File.expand_path("../../../lib/airbrussh/capistrano.rb", __FILE__))
+    @stderr_orig = $stderr
+    @stderr = StringIO.new
+    $stderr = @stderr
+  end
+
+  def teardown
+    $stderr = @stderr_orig
+  end
+
+  def test_configures_for_capistrano
+    assert_equal("log/capistrano.log", Airbrussh.configuration.log_file)
+    assert(Airbrussh.configuration.monkey_patch_rake)
+    assert_equal(:auto, Airbrussh.configuration.color)
+    assert_equal(:auto, Airbrussh.configuration.truncate)
+    assert_equal(:auto, Airbrussh.configuration.banner)
+    refute(Airbrussh.configuration.command_output)
+  end
+
+  def test_defines_tasks
+    assert_instance_of(Rake::Task, Rake.application["load:defaults"])
+    assert_instance_of(Rake::Task, Rake.application["deploy:failed"])
+  end
+
+  def test_sets_airbrussh_formatter_on_load_defaults
+    load_defaults = Rake.application["load:defaults"]
+    load_defaults.invoke
+    assert_equal([:format, :airbrussh], Capistrano::MockDSL.set_args)
+  end
+
+  def test_prints_last_20_logfile_lines_on_deploy_failure
+    log_file = Tempfile.create("airbrussh-test-")
+    begin
+      log_file.write((11..31).map { |i| "line #{i}\n" }.join)
+      log_file.close
+
+      Airbrussh.configuration.stubs(:log_file => log_file.path)
+      Rake.application["deploy:failed"].invoke
+
+      assert_match("DEPLOY FAILED", stderr)
+      refute_match("line 11", stderr)
+      (12..31).each { |i| assert_match("line #{i}", stderr) }
+    ensure
+      File.unlink(log_file.path)
+    end
+  end
+
+  def test_does_not_print_anything_on_deploy_failure_if_nil_logfile
+    Airbrussh.configuration.stubs(:log_file => nil)
+    Rake.application["deploy:failed"].invoke
+    assert_empty(stderr)
+  end
+
+  private
+
+  def stderr
+    @stderr.string
+  end
+end

--- a/test/support/mocha.rb
+++ b/test/support/mocha.rb
@@ -1,0 +1,4 @@
+require "mocha/mini_test"
+
+Mocha::Configuration.warn_when(:stubbing_non_existent_method)
+Mocha::Configuration.warn_when(:stubbing_non_public_method)


### PR DESCRIPTION
@robd This is my attempt at adding tests for `airbrussh/capistrano`. It is really messy: I have to do things like substitute `$stderr` and mock up a `set` method on the main object in order to inspect the output and simulate a Capistrano/Rake environment.

If you have a chance to review, I'd appreciate your feedback and any ideas on how to factor this more cleanly.