### PR TITLE
Refactor airbrussh/capistrano to allow for easier testing; add tests

### DIFF
--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"
+  spec.add_development_dependency "mocha"
   spec.add_development_dependency "rubocop", ">= 0.31.0"
 end

--- a/lib/airbrussh/capistrano.rb
+++ b/lib/airbrussh/capistrano.rb
@@ -1,46 +1,17 @@
-require "airbrussh"
-require "airbrussh/colors"
-require "airbrussh/console"
-require "sshkit/formatter/airbrussh"
-require "shellwords"
+require "airbrussh/capistrano/tasks"
 
-# airbrush/capistrano uses a different default configuration
-Airbrussh.configure do |config|
-  config.log_file = "log/capistrano.log"
-  config.monkey_patch_rake = true
-end
-
-# Sanity check!
-unless defined?(Capistrano) && defined?(:namespace)
-  $stderr.puts(
-    Airbrussh::Colors.red(
-      "WARNING: airbrussh/capistrano must be loaded by Capistrano in order "\
-      "to work.\nRequire this gem within your application's Capfile, as "\
-      "described here:\nhttps://github.com/mattbrictson/airbrussh#installation"
-    ))
-end
+tasks = Airbrussh::Capistrano::Tasks.new(self)
 
 # Hook into Capistrano's init process to set the formatter
 namespace :load do
   task :defaults do
-    set :format, :airbrussh
+    tasks.load_defaults
   end
 end
 
 # Capistrano failure hook
 namespace :deploy do
   task :failed do
-    log_file = Airbrussh.configuration.log_file
-    next if log_file.nil?
-
-    err = Airbrussh::Console.new($stderr)
-    err.print_line
-    err.print_line(Airbrussh::Colors.red("** DEPLOY FAILED"))
-    err.print_line(
-      Airbrussh::Colors.yellow(
-        "** Refer to #{log_file} for details. Here are the last 20 lines:"
-      ))
-    err.print_line
-    system("tail -n 20 #{log_file.shellescape} 1>&2")
+    tasks.deploy_failed
   end
 end

--- a/lib/airbrussh/capistrano/tasks.rb
+++ b/lib/airbrussh/capistrano/tasks.rb
@@ -1,0 +1,79 @@
+require "airbrussh"
+require "airbrussh/colors"
+require "airbrussh/console"
+require "forwardable"
+require "shellwords"
+
+module Airbrussh
+  module Capistrano
+    # Encapsulates the rake behavior that integrates Airbrussh into Capistrano.
+    # This class allows us to easily test the behavior using a mock to stand in
+    # for the Capistrano DSL.
+    #
+    # See airbrussh/capistrano.rb to see how this class is used.
+    #
+    class Tasks
+      extend Forwardable
+      def_delegators :dsl, :set
+      def_delegators :config, :log_file
+
+      include Airbrussh::Colors
+
+      def initialize(dsl, stderr=$stderr, config=Airbrussh.configuration)
+        @dsl = dsl
+        @stderr = stderr
+        @config = config
+
+        configure
+        warn_if_missing_dsl
+      end
+
+      # Behavior for the rake load:defaults task.
+      def load_defaults
+        set :format, :airbrussh
+      end
+
+      # Behavior for the rake deploy:failed task.
+      def deploy_failed
+        return if log_file.nil?
+
+        error_line
+        error_line(red("** DEPLOY FAILED"))
+        error_line(yellow("** Refer to #{log_file} for details. "\
+                          "Here are the last 20 lines:"))
+        error_line
+        error_line(`tail -n 20 #{log_file.shellescape} 2>&1`)
+      end
+
+      private
+
+      attr_reader :dsl, :stderr, :config
+
+      # Change airbrussh's default configuration to be more appropriate for
+      # capistrano.
+      def configure
+        config.log_file = "log/capistrano.log"
+        config.monkey_patch_rake = true
+      end
+
+      # Verify that capistrano and rake DSLs are present
+      def warn_if_missing_dsl
+        return if %w(set namespace task).all? { |m| dsl.respond_to?(m) }
+
+        error_line(
+          red("WARNING: airbrussh/capistrano must be loaded by Capistrano in "\
+              "order to work.\nRequire this gem within your application's "\
+              "Capfile, as described here:\n"\
+              "https://github.com/mattbrictson/airbrussh#installation"))
+      end
+
+      def err_console
+        @err_console ||= Airbrussh::Console.new(stderr)
+      end
+
+      def error_line(line="\n")
+        line.each_line(&err_console.method(:print_line))
+      end
+    end
+  end
+end

--- a/lib/airbrussh/colors.rb
+++ b/lib/airbrussh/colors.rb
@@ -10,8 +10,6 @@ module Airbrussh
       :gray   => 90
     }.freeze
 
-    module_function
-
     # Define red, green, blue, etc. methods that return a copy of the
     # String that is wrapped in the corresponding ANSI color escape
     # sequence.
@@ -19,6 +17,7 @@ module Airbrussh
       define_method(name) do |string|
         "\e[0;#{code};49m#{string}\e[0m"
       end
+      module_function(name)
     end
   end
 end

--- a/test/airbrussh/capistrano/tasks_test.rb
+++ b/test/airbrussh/capistrano/tasks_test.rb
@@ -1,0 +1,78 @@
+require "minitest_helper"
+require "airbrussh/capistrano/tasks"
+require "airbrussh/configuration"
+require "stringio"
+require "tempfile"
+
+class Airbrussh::Capistrano::TasksTest < Minitest::Test
+  class DSL
+    def set(*)
+    end
+
+    def namespace(*)
+    end
+
+    def task(*)
+    end
+  end
+
+  def setup
+    @dsl = DSL.new
+    @config = Airbrussh::Configuration.new
+    @stderr = StringIO.new
+    @tasks = Airbrussh::Capistrano::Tasks.new(@dsl, @stderr, @config)
+  end
+
+  def test_no_warning_is_printed_when_proper_dsl_is_present
+    assert_empty(stderr)
+  end
+
+  def test_prints_warning_if_dsl_is_missing
+    bad_dsl = Object.new
+    Airbrussh::Capistrano::Tasks.new(bad_dsl, @stderr, @config)
+    assert_match(/WARNING.*must be loaded by Capistrano/, stderr)
+  end
+
+  def test_configures_for_capistrano
+    assert_equal("log/capistrano.log", @config.log_file)
+    assert(@config.monkey_patch_rake)
+    assert_equal(:auto, @config.color)
+    assert_equal(:auto, @config.truncate)
+    assert_equal(:auto, @config.banner)
+    refute(@config.command_output)
+  end
+
+  def test_sets_airbrussh_formatter_on_load_defaults
+    @dsl.expects(:set).with(:format, :airbrussh)
+    @tasks.load_defaults
+  end
+
+  def test_prints_last_20_logfile_lines_on_deploy_failure
+    log_file = Tempfile.new("airbrussh-test-")
+    begin
+      log_file.write((11..31).map { |i| "line #{i}\n" }.join)
+      log_file.close
+
+      @config.log_file = log_file.path
+      @tasks.deploy_failed
+
+      assert_match("DEPLOY FAILED", stderr)
+      refute_match("line 11", stderr)
+      (12..31).each { |i| assert_match("line #{i}", stderr) }
+    ensure
+      log_file.unlink
+    end
+  end
+
+  def test_does_not_print_anything_on_deploy_failure_if_nil_logfile
+    @config.log_file = nil
+    @tasks.deploy_failed
+    assert_empty(stderr)
+  end
+
+  private
+
+  def stderr
+    @stderr.string
+  end
+end

--- a/test/airbrussh/capistrano_test.rb
+++ b/test/airbrussh/capistrano_test.rb
@@ -1,11 +1,13 @@
 require "minitest_helper"
-require "airbrussh/capistrano"
-
-# Note: because this test requires airbrussh/capistrano outside of a Capistrano
-# environment, a WARNING... message will be printed to stderr. This message can
-# be disregarded.
 
 class Airbrussh::CapistranoTest < Minitest::Test
+  def setup
+    # Mute the warning that is normally printed to $stderr when
+    # airbrussh/capistrano is required outside a capistrano runtime.
+    $stderr.stubs(:write)
+    require "airbrussh/capistrano"
+  end
+
   def teardown
     Airbrussh::Rake::Context.current_task_name = nil
   end

--- a/test/airbrussh/capistrano_test.rb
+++ b/test/airbrussh/capistrano_test.rb
@@ -1,0 +1,27 @@
+require "minitest_helper"
+require "airbrussh/capistrano"
+
+# Note: because this test requires airbrussh/capistrano outside of a Capistrano
+# environment, a WARNING... message will be printed to stderr. This message can
+# be disregarded.
+
+class Airbrussh::CapistranoTest < Minitest::Test
+  def teardown
+    Airbrussh::Rake::Context.current_task_name = nil
+  end
+
+  def test_defines_tasks
+    assert_instance_of(Rake::Task, Rake.application["load:defaults"])
+    assert_instance_of(Rake::Task, Rake.application["deploy:failed"])
+  end
+
+  def test_load_defaults_rake_task_delegates_to_tasks_instance
+    Airbrussh::Capistrano::Tasks.any_instance.expects(:load_defaults)
+    Rake.application["load:defaults"].execute
+  end
+
+  def test_deploy_failed_rake_task_delegates_to_tasks_instance
+    Airbrussh::Capistrano::Tasks.any_instance.expects(:deploy_failed)
+    Rake.application["deploy:failed"].execute
+  end
+end

--- a/test/support/mocha.rb
+++ b/test/support/mocha.rb
@@ -1,0 +1,4 @@
+require "mocha/mini_test"
+
+Mocha::Configuration.warn_when(:stubbing_non_existent_method)
+Mocha::Configuration.warn_when(:stubbing_non_public_method)


### PR DESCRIPTION
I've moved all the implementation of the capistrano integration into a new class, `Airbrussh::Capistrano::Tasks`. This class uses DI to allow for easy testing. The `airbrussh/capistrano.rb` code is now trivial and can be easily tested as well.

The only minor issue is that since the tests are running outside of a full Capistrano environment, the "Capistrano is not installed" warning is printed to stderr when running the test suite. Rather than add a hack to mute this warning during tests, I decided to just allow the warning to be printed.

@robd This is not a *true* integration test (which would be running a `cap` command in e.g. Vagrant), but it is pretty close and I think it still has value. What do you think?