### PR TITLE
Introduce DelegatingFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Airbrussh is in a pre-1.0 state. This means that its APIs and behavior are subje
 
 ## [Unreleased]
 
+If you are using Airbrussh outside of Capistrano, note that the formatter class has changed. Instead of using `Airbrussh::Formatter`, you now should use `SSHKit::Formatter::Airbrussh`. For example:
+
+```ruby
+require "sshkit/formatter/airbrussh"
+SSHKit.config.output = SSHKit::Formatter::Airbrussh.new($stdout)
+```
+
+Capistrano users should still use `require "airbrussh/capistrano"` in the `Capfile` to automatically load and install Airbrussh. This has not changed.
+
 * Your contribution here!
 * Bundler 1.10 is now required to build and test airbrussh (this doesn't affect users of airbrussh at all).
 * If the directory containing the log file doesn't exist, Airbrussh will now attempt to create it using `FileUtils.mkdir_p` ([#30](https://github.com/mattbrictson/airbrussh/issues/30))

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ end
 If you are using SSHKit directly, you can use Airbrussh without the Capistrano magic:
 
 ```ruby
-require "airbrussh"
-SSHKit.config.output = Airbrussh::Formatter.new($stdout)
+require "sshkit/formatter/airbrussh"
+SSHKit.config.output = SSHKit::Formatter::Airbrussh.new($stdout)
 ```
 
 When Capistrano is not present, Airbrussh uses a slightly different default configuration:

--- a/lib/airbrussh/configuration.rb
+++ b/lib/airbrussh/configuration.rb
@@ -1,3 +1,5 @@
+require "airbrussh/formatter"
+
 module Airbrussh
   class Configuration
     attr_accessor :log_file, :monkey_patch_rake, :color, :truncate, :banner,
@@ -10,6 +12,17 @@ module Airbrussh
       self.truncate = :auto
       self.banner = :auto
       self.command_output = false
+    end
+
+    # This returns an array of formatters appropriate for the configuration.
+    # Currently this always returns a single Airbrussh::Formatter, but in the
+    # future this may include a second formatter which has the sole purpose
+    # of writing to the log_file, if a log_file is specified. This change will
+    # happen once the file-related IO responsibilities are factored out of
+    # Airbrussh::Formatter into a new class.
+    #
+    def formatters(io)
+      [Airbrussh::Formatter.new(io, self)]
     end
 
     def show_command_output?(sym)

--- a/lib/airbrussh/delegating_formatter.rb
+++ b/lib/airbrussh/delegating_formatter.rb
@@ -1,0 +1,23 @@
+require "sshkit"
+
+module Airbrussh
+  class DelegatingFormatter
+    FORWARDED_METHODS = %w(
+      fatal error warn info debug log
+      log_command_start log_command_data log_command_exit
+      << write
+    )
+
+    attr_reader :formatters
+
+    def initialize(formatters)
+      @formatters = formatters
+    end
+
+    FORWARDED_METHODS.each do |method|
+      define_method(method) do |*args|
+        formatters.map { |f| f.public_send(method, *args) }.last
+      end
+    end
+  end
+end

--- a/lib/sshkit/formatter/airbrussh.rb
+++ b/lib/sshkit/formatter/airbrussh.rb
@@ -1,12 +1,14 @@
-require "airbrussh/formatter"
+require "airbrussh"
+require "airbrussh/delegating_formatter"
 
 # Capistrano's formatter configuration requires that the formatter class
-# be in the SSHKit::Formatter namespace. So we declare
-# SSHKit::Formatter::Airbrussh that simply functions as an alias for
-# Airbrussh::Formatter.
+# be in the SSHKit::Formatter namespace.
 module SSHKit
   module Formatter
-    class Airbrussh < Airbrussh::Formatter
+    class Airbrussh < Airbrussh::DelegatingFormatter
+      def initialize(io, config=::Airbrussh.configuration)
+        super(config.formatters(io))
+      end
     end
   end
 end

--- a/test/airbrussh/configuration_test.rb
+++ b/test/airbrussh/configuration_test.rb
@@ -14,6 +14,15 @@ class Airbrussh::ConfigurationTest < Minitest::Test
     refute(@config.command_output)
   end
 
+  def test_formatters
+    io = StringIO.new
+    formatters = @config.formatters(io)
+    assert_equal(1, formatters.length)
+    assert_instance_of(Airbrussh::Formatter, formatters.first)
+    assert_equal(io, formatters.first.original_output)
+    assert_equal(@config, formatters.first.config)
+  end
+
   def test_effects_of_command_output_true
     @config.command_output = true
     assert(@config.show_command_output?(:stdout))

--- a/test/airbrussh/delegating_formatter_test.rb
+++ b/test/airbrussh/delegating_formatter_test.rb
@@ -1,0 +1,44 @@
+require "minitest_helper"
+require "airbrussh/delegating_formatter"
+
+class Airbrussh::DelegatingFormatterTest < Minitest::Test
+  def setup
+    @fmt_1 = stub
+    @fmt_2 = stub
+    @delegating = Airbrussh::DelegatingFormatter.new([@fmt_1, @fmt_2])
+  end
+
+  def test_forwards_logger_methods
+    %w(fatal error warn info debug log).each do |method|
+      @fmt_1.expects(method).with("string").returns(6)
+      @fmt_2.expects(method).with("string").returns(6)
+      result = @delegating.public_send(method, "string")
+      assert_equal(6, result)
+    end
+  end
+
+  def test_forwards_start_and_exit_methods
+    %w(log_command_start log_command_exit).each do |method|
+      @fmt_1.expects(method).with(:command).returns(nil)
+      @fmt_2.expects(method).with(:command).returns(nil)
+      result = @delegating.public_send(method, :command)
+      assert_nil(result)
+    end
+  end
+
+  def test_forwards_log_command_data
+    @fmt_1.expects(:log_command_data).with(:command, :stdout, "a").returns(nil)
+    @fmt_2.expects(:log_command_data).with(:command, :stdout, "a").returns(nil)
+    result = @delegating.log_command_data(:command, :stdout, "a")
+    assert_nil(result)
+  end
+
+  def test_forwards_io_methods
+    %w(<< write).each do |method|
+      @fmt_1.expects(method).with("hello").returns(5)
+      @fmt_2.expects(method).with("hello").returns(5)
+      result = @delegating.public_send(method, "hello")
+      assert_equal(5, result)
+    end
+  end
+end

--- a/test/sshkit/formatter/airbrussh_test.rb
+++ b/test/sshkit/formatter/airbrussh_test.rb
@@ -1,0 +1,13 @@
+require "minitest_helper"
+require "sshkit/formatter/airbrussh"
+
+class SSHKit::Formatter::AirbrusshTest < Minitest::Test
+  def test_uses_formatters_from_configuration_object
+    io = stub
+    config = Airbrussh::Configuration.new
+    config.expects(:formatters).with(io).returns([:fmt1, :fmt2])
+
+    formatter = SSHKit::Formatter::Airbrussh.new(io, config)
+    assert_equal([:fmt1, :fmt2], formatter.formatters)
+  end
+end


### PR DESCRIPTION
This PR contains the first round of refactoring as discussed in #24.

Specifically, this adds `DelegatingFormatter`, which forwards logging methods to 1 or more other formatters. This will allow us to split out the responsibilities of console logging and file (pretty) logging into two separate formatter classes.

I have not yet done this split, so this PR is just laying the groundwork.

@robd I'd be interested in hearing your feedback if you have time. I would like to make sure this is going in the right direction before doing further refactoring.

One interesting consequence of this PR is that `SSHKit::Formatter::Airbrussh` is now more than just an alias for `Airbrussh::Formatter`: the former now potentially delegates to multiple formatters. As a result, users of Airbrussh will need to use `SSHKit::Formatter::Airbrussh` if they want the correct behavior. So this is an API break. (Although we are pre-1.0, so I guess that doesn't really matter.)