### PR TITLE
Fix non sequential command nos

### DIFF
--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -28,22 +28,22 @@ module Airbrussh
     end
 
     def log_command_start(command)
-      command = decorate(command)
       return if debug?(command)
+      command = decorate(command)
       print_task_if_changed
       print_indented_line(command.start_message) if command.first_execution?
     end
 
     def log_command_data(command, stream_type, line)
+      return if debug?(command)
+      return unless config.show_command_output?(stream_type)
       command = decorate(command)
-      hide_command_output = !config.show_command_output?(stream_type)
-      return if hide_command_output || debug?(command)
       print_indented_line(command.format_output(line))
     end
 
     def log_command_exit(command)
-      command = decorate(command)
       return if debug?(command)
+      command = decorate(command)
       print_indented_line(command.exit_message(@log_file), -2)
     end
 

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -42,10 +42,10 @@ module Airbrussh
     def write(obj)
       case obj
       when SSHKit::Command
-        write_command_start(obj)
+        log_command_start(obj)
         write_command_output(obj, :stderr)
         write_command_output(obj, :stdout)
-        write_command_exit(obj) if obj.finished?
+        log_command_exit(obj) if obj.finished?
       when SSHKit::LogMessage
         write_log_message(obj)
       end
@@ -77,7 +77,7 @@ module Airbrussh
       output = command.public_send(stream)
       return if output.empty?
       output.lines.to_a.each do |line|
-        write_command_output_line(command, stream, line)
+        log_command_data(command, stream, line)
       end
       command.public_send("#{stream}=", "")
     end

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -28,28 +28,24 @@ module Airbrussh
     end
 
     def log_command_start(command)
-      command = decorate(command)
       write_command_start(command)
     end
 
     def log_command_data(command, stream_type, line)
-      command = decorate(command)
       write_command_output_line(command, stream_type, line)
     end
 
     def log_command_exit(command)
-      command = decorate(command)
       write_command_exit(command)
     end
 
     def write(obj)
       case obj
       when SSHKit::Command
-        command = decorate(obj)
-        write_command_start(command)
-        write_command_output(command, :stderr)
-        write_command_output(command, :stdout)
-        write_command_exit(command) if command.finished?
+        write_command_start(obj)
+        write_command_output(obj, :stderr)
+        write_command_output(obj, :stdout)
+        write_command_exit(obj) if obj.finished?
       when SSHKit::LogMessage
         write_log_message(obj)
       end
@@ -67,6 +63,7 @@ module Airbrussh
     end
 
     def write_command_start(command)
+      command = decorate(command)
       return if debug?(command)
       print_task_if_changed
       print_indented_line(command.start_message) if command.first_execution?
@@ -86,6 +83,7 @@ module Airbrussh
     end
 
     def write_command_output_line(command, stream, line)
+      command = decorate(command)
       hide_command_output = !config.show_command_output?(stream)
       return if hide_command_output || debug?(command)
       print_indented_line(command.format_output(line))
@@ -100,6 +98,7 @@ module Airbrussh
     end
 
     def write_command_exit(command)
+      command = decorate(command)
       return if debug?(command)
       print_indented_line(command.exit_message(@log_file), -2)
     end

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -51,8 +51,8 @@ module Airbrussh
       case obj
       when SSHKit::Command
         log_command_start(obj)
-        write_command_output(obj, :stderr)
-        write_command_output(obj, :stdout)
+        log_and_clear_command_output(obj, :stderr)
+        log_and_clear_command_output(obj, :stdout)
         log_command_exit(obj) if obj.finished?
       when SSHKit::LogMessage
         write_log_message(obj)
@@ -72,9 +72,9 @@ module Airbrussh
 
     # For SSHKit versions up to and including 1.7.1, the stdout and stderr
     # output was available as attributes on the Command. Print the data for
-    # the specified command and stream if enabled
+    # the specified command and stream if enabled and clear the stream.
     # (see Airbrussh::Configuration#command_output).
-    def write_command_output(command, stream)
+    def log_and_clear_command_output(command, stream)
       output = command.public_send(stream)
       return if output.empty?
       output.lines.to_a.each do |line|


### PR DESCRIPTION
This PR fixes #43, where there are gaps in the command number sequence. This was due to the command number being incremented by debug commands which aren't displayed by the Airbrussh console logger.

This PR replaces #41 which was coincidentally helpful in solving this bug.