### PR TITLE
Run rubocop at the end of test_all.rb

### DIFF
--- a/bin/test_all.rb
+++ b/bin/test_all.rb
@@ -9,6 +9,8 @@ YAML.load_file(".travis.yml")["env"].each do |sshkit_version|
   system("#{sshkit_version} bundle exec rake test")
 end
 
+system("bundle exec rake rubocop")
+
 at_exit do
   puts "\e[0;34;49m== Resetting sshkit ==\e[0m"
   system("bundle update")


### PR DESCRIPTION
I'm a bit bored of forgetting to run rubocop separately after running test_all.rb, so I think it's worth running it automatically.