### PR TITLE
Remove context.decorate_command side effects

### DIFF
--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -11,7 +11,7 @@ module Airbrussh
     extend Forwardable
 
     attr_reader :config, :context
-    def_delegator :context, :current_task_name
+    def_delegators :context, :current_task_name, :register_new_command
 
     def initialize(io, config=Airbrussh.configuration)
       super(io)
@@ -29,9 +29,10 @@ module Airbrussh
 
     def log_command_start(command)
       return if debug?(command)
+      first_execution = register_new_command(command)
       command = decorate(command)
       print_task_if_changed
-      print_indented_line(command.start_message) if command.first_execution?
+      print_indented_line(command.start_message) if first_execution
     end
 
     def log_command_data(command, stream_type, line)

--- a/lib/airbrussh/rake/command.rb
+++ b/lib/airbrussh/rake/command.rb
@@ -4,22 +4,15 @@ module Airbrussh
   module Rake
     # Decorates an SSHKit Command to add Rake-specific contextual information:
     #
-    # * first_execution? - is this the first time this command has been run in
-    #                      the context of the current rake task?
     # * position - zero-based position of this command in the list of
     #              all commands that have been run in the current rake task
     #
     class Command < SimpleDelegator
-      attr_reader :first_execution, :position
+      attr_reader :position
 
-      def initialize(command, first_execution, position)
+      def initialize(command, position)
         super(command)
-        @first_execution = first_execution
         @position = position
-      end
-
-      def first_execution?
-        first_execution
       end
     end
   end

--- a/test/airbrussh/rake/command_test.rb
+++ b/test/airbrussh/rake/command_test.rb
@@ -4,7 +4,7 @@ require "airbrussh/rake/command"
 class Airbrussh::Rake::CommandTest < Minitest::Test
   def setup
     original = %w(foo bar)
-    @command = Airbrussh::Rake::Command.new(original, true, 1)
+    @command = Airbrussh::Rake::Command.new(original, 1)
   end
 
   def test_delegates_to_original_object
@@ -13,7 +13,6 @@ class Airbrussh::Rake::CommandTest < Minitest::Test
   end
 
   def test_contextual_data
-    assert(@command.first_execution?)
     assert_equal(1, @command.position)
   end
 end

--- a/test/airbrussh/rake/context_test.rb
+++ b/test/airbrussh/rake/context_test.rb
@@ -40,25 +40,23 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
     context = Airbrussh::Rake::Context.new(@config)
 
     define_and_execute_rake_task("one") do
-      context.decorate_command(:command_one)
+      context.register_new_command(:command_one)
       command_one = context.decorate_command(:command_one)
-      context.decorate_command(:command_two)
+      context.register_new_command(:command_two)
       command_two = context.decorate_command(:command_two)
 
       assert_equal(0, command_one.position)
       assert_equal(1, command_two.position)
-      refute(command_one.first_execution?)
-      refute(command_two.first_execution?)
     end
 
     define_and_execute_rake_task("two") do
+      context.register_new_command(:command_three)
       command_three = context.decorate_command(:command_three)
+      context.register_new_command(:command_four)
       command_four = context.decorate_command(:command_four)
 
       assert_equal(0, command_three.position)
       assert_equal(1, command_four.position)
-      assert(command_three.first_execution?)
-      assert(command_four.first_execution?)
     end
   end
 end

--- a/test/airbrussh/rake/context_test.rb
+++ b/test/airbrussh/rake/context_test.rb
@@ -35,6 +35,24 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
     end
   end
 
+  def test_register_new_command_is_true_for_first_execution_per_rake_task
+    @config.monkey_patch_rake = true
+    context = Airbrussh::Rake::Context.new(@config)
+    define_and_execute_rake_task("one") do
+      assert context.register_new_command(:command_one)
+      refute context.register_new_command(:command_one)
+      assert context.register_new_command(:command_two)
+      refute context.register_new_command(:command_two)
+    end
+
+    define_and_execute_rake_task("two") do
+      assert context.register_new_command(:command_one)
+      refute context.register_new_command(:command_one)
+      assert context.register_new_command(:command_two)
+      refute context.register_new_command(:command_two)
+    end
+  end
+
   def test_decorate_command
     @config.monkey_patch_rake = true
     context = Airbrussh::Rake::Context.new(@config)


### PR DESCRIPTION
This PR was inspired by #45. In that PR it was non obvious that `context.decorate_command` should not have been called for debug commands because it has side effects. These side effects are clearing the command history and updating the first_execution? flag.

They should only occur in the `log_command_start` method. Also the first_execution? flag is only required to guard the `command.start_message` and is only used in the `log_command_start` method.

Therefore, I've introduced a new method - `register_new_command`, which makes the side effects explicit and is only called in `log_command_start`. Since the `first_execution?` is also only needed in `log_command_start`, I removed this from `Airbrussh::Rake::Command` and just made it the return value of `register_new_command`.

This means that `decorate(command)` is now side effect free and I think this makes the code easier to reason about.

I'm not sure if the method name `register_new_command` is ideal; but I couldn't think of a name of reasonable length, It's something like `clear_history_and_update_current_rake_task`

I've tested a full NetSSH deploy against SSHKit master, and run a simple test task against 1.7.1. Looks OK AFAICT.

@mattbrictson Let me know if you think this is an improvement