### PR TITLE
Handle multi-line strings in log_command_data

### DIFF
--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -34,11 +34,13 @@ module Airbrussh
       print_indented_line(command.start_message) if first_execution
     end
 
-    def log_command_data(command, stream_type, line)
+    def log_command_data(command, stream_type, string)
       return if debug?(command)
       return unless config.show_command_output?(stream_type)
       command = decorate(command)
-      print_indented_line(command.format_output(line))
+      string.each_line do |line|
+        print_indented_line(command.format_output(line))
+      end
     end
 
     def log_command_exit(command)

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -78,10 +78,7 @@ module Airbrussh
     # (see Airbrussh::Configuration#command_output).
     def log_and_clear_command_output(command, stream)
       output = command.public_send(stream)
-      return if output.empty?
-      output.lines.to_a.each do |line|
-        log_command_data(command, stream, line)
-      end
+      log_command_data(command, stream, output)
       command.public_send("#{stream}=", "")
     end
 

--- a/test/airbrussh/console_formatter_test.rb
+++ b/test/airbrussh/console_formatter_test.rb
@@ -1,7 +1,37 @@
 require "minitest_helper"
+require "stringio"
+require "airbrussh/configuration"
+require "airbrussh/console_formatter"
 
 # ConsoleFormatter is currently tested via a comprehensive acceptance-style
 # test in Airbrussh::FormatterTest. Hence the lack of unit tests here, which
 # would be redundant.
 class Airbrussh::ConsoleFormatterTest < Minitest::Test
+  def setup
+    @config = Airbrussh::Configuration.new
+    @config.banner = false
+    @config.command_output = true
+    @output = StringIO.new
+    @formatter = Airbrussh::ConsoleFormatter.new(@output, @config)
+  end
+
+  # Make sure that command data containing two lines is formatted as two
+  # indented lines.
+  def test_log_command_data_with_multiline_string
+    command = stub(:verbosity => SSHKit::Logger::INFO, :to_s => "greet")
+    data = "hello\nworld\n"
+    @formatter.log_command_start(command)
+    @formatter.log_command_data(command, :stdout, data)
+    assert_equal(
+      "      01 greet\n"\
+      "      01 hello\n"\
+      "      01 world\n",
+      output)
+  end
+
+  private
+
+  def output
+    @output.string
+  end
 end


### PR DESCRIPTION
This PR is a fix for #44. The bug was caused by `log_command_output` being called with a multi-line string. Airbrussh was not properly splitting them into separate lines before indenting and prefixing the output.

Unfortunately, this is another case where the local backend does not allow us to write an appropriate acceptance test. The local backend uses `gets` to obtain the command output, so `log_command_output` can never receive a multi-line string. This is different from the net-ssh backend, which logs arbitrary chunks of data it receives from the network.

Instead I've written a unit test for `ConsoleFormatter#log_command_output` to verify the desired behavior. I also tested a `cap deploy` against this branch and verified the bug as fixed.

@robd Does this look good to you?