### PR TITLE
Support repeated commands

### DIFF
--- a/lib/airbrussh/rake/context.rb
+++ b/lib/airbrussh/rake/context.rb
@@ -31,15 +31,17 @@ module Airbrussh
       def register_new_command(command)
         reset_history_if_task_changed
 
-        first_execution = !history.include?(command.to_s)
-        history << command.to_s
-        history.uniq!
+        first_execution = position(command).nil?
+        history << command if first_execution
         first_execution
       end
 
       # The position of the specified command in the current rake task
       def position(command)
-        history.index(command.to_s)
+        history.each.with_index do |previous_command, index|
+          return index if previous_command.uuid == command.uuid
+        end
+        nil
       end
 
       class << self

--- a/test/airbrussh/console_formatter_test.rb
+++ b/test/airbrussh/console_formatter_test.rb
@@ -18,7 +18,11 @@ class Airbrussh::ConsoleFormatterTest < Minitest::Test
   # Make sure that command data containing two lines is formatted as two
   # indented lines.
   def test_log_command_data_with_multiline_string
-    command = stub(:verbosity => SSHKit::Logger::INFO, :to_s => "greet")
+    command = stub(
+      :verbosity => SSHKit::Logger::INFO,
+      :to_s => "greet",
+      :uuid => "a1"
+    )
     data = "hello\nworld\n"
     @formatter.log_command_start(command)
     @formatter.log_command_data(command, :stdout, data)

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -330,13 +330,15 @@ class Airbrussh::FormatterTest < Minitest::Test
       "      01 echo command 1\n",
       "      01 command 1\n",
       /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
-      "      01 command 1\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
-      "      02 echo command 2\n",
-      "      02 command 2\n",
+      "      02 echo command 1\n",
+      "      02 command 1\n",
       /    ✔ 02 #{@user}@localhost 0.\d+s\n/,
-      "      01 command 1\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/
+      "      03 echo command 2\n",
+      "      03 command 2\n",
+      /    ✔ 03 #{@user}@localhost 0.\d+s\n/,
+      "      04 echo command 1\n",
+      "      04 command 1\n",
+      /    ✔ 04 #{@user}@localhost 0.\d+s\n/
     )
   end
 

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -312,6 +312,34 @@ class Airbrussh::FormatterTest < Minitest::Test
     )
   end
 
+  def test_repeated_commands
+    configure do |airbrussh_config|
+      airbrussh_config.monkey_patch_rake = true
+      airbrussh_config.command_output = true
+    end
+
+    on_local("interleaving_test") do
+      execute(:echo, "command 1")
+      execute(:echo, "command 1")
+      execute(:echo, "command 2")
+      execute(:echo, "command 1")
+    end
+
+    assert_output_lines(
+      "00:00 interleaving_test\n",
+      "      01 echo command 1\n",
+      "      01 command 1\n",
+      /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
+      "      01 command 1\n",
+      /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
+      "      02 echo command 2\n",
+      "      02 command 2\n",
+      /    ✔ 02 #{@user}@localhost 0.\d+s\n/,
+      "      01 command 1\n",
+      /    ✔ 01 #{@user}@localhost 0.\d+s\n/
+    )
+  end
+
   private
 
   def on_local(task_name=nil, &block)

--- a/test/airbrussh/rake/context_test.rb
+++ b/test/airbrussh/rake/context_test.rb
@@ -38,18 +38,22 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
   def test_register_new_command_is_true_for_first_execution_per_rake_task
     @config.monkey_patch_rake = true
     context = Airbrussh::Rake::Context.new(@config)
+
+    command_one = stub(:uuid => "command_one")
+    command_two = stub(:uuid => "command_two")
+
     define_and_execute_rake_task("one") do
-      assert context.register_new_command(:command_one)
-      refute context.register_new_command(:command_one)
-      assert context.register_new_command(:command_two)
-      refute context.register_new_command(:command_two)
+      assert context.register_new_command(command_one)
+      refute context.register_new_command(command_one)
+      assert context.register_new_command(command_two)
+      refute context.register_new_command(command_two)
     end
 
     define_and_execute_rake_task("two") do
-      assert context.register_new_command(:command_one)
-      refute context.register_new_command(:command_one)
-      assert context.register_new_command(:command_two)
-      refute context.register_new_command(:command_two)
+      assert context.register_new_command(command_one)
+      refute context.register_new_command(command_one)
+      assert context.register_new_command(command_two)
+      refute context.register_new_command(command_two)
     end
   end
 
@@ -57,20 +61,25 @@ class Airbrussh::Rake::ContextTest < Minitest::Test
     @config.monkey_patch_rake = true
     context = Airbrussh::Rake::Context.new(@config)
 
-    define_and_execute_rake_task("one") do
-      context.register_new_command(:command_one)
-      context.register_new_command(:command_two)
+    command_one = stub(:uuid => "command_one")
+    command_two = stub(:uuid => "command_two")
+    command_three = stub(:uuid => "command_three")
+    command_four = stub(:uuid => "command_four")
 
-      assert_equal(0, context.position(:command_one))
-      assert_equal(1, context.position(:command_two))
+    define_and_execute_rake_task("one") do
+      context.register_new_command(command_one)
+      context.register_new_command(command_two)
+
+      assert_equal(0, context.position(command_one))
+      assert_equal(1, context.position(command_two))
     end
 
     define_and_execute_rake_task("two") do
-      context.register_new_command(:command_three)
-      context.register_new_command(:command_four)
+      context.register_new_command(command_three)
+      context.register_new_command(command_four)
 
-      assert_equal(0, context.position(:command_three))
-      assert_equal(1, context.position(:command_four))
+      assert_equal(0, context.position(command_three))
+      assert_equal(1, context.position(command_four))
     end
   end
 end


### PR DESCRIPTION
First part of #53 

I didn't need to do that rework of the command history to remove the `clear` method, but I still think it would be worth doing.

I tested this with my test cap task on SSHKit master, SSHKit 1.7.1 with NetSSH.

```ruby
  task :test do
    on roles :web do
      execute(:ls, '-al')
      execute(:echo, 'hello')
      execute(:ls, '-al')
      execute(:echo, 'hello')
      execute(:ls, '-al')
    end
  end
```

Numbering now all looks good.