### PR TITLE
Changes to allow `rake test` to work on Windows; set up Windows-based CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/airbrussh.svg)](http://badge.fury.io/rb/airbrussh)
 [![Build Status](https://travis-ci.org/mattbrictson/airbrussh.svg?branch=master)](https://travis-ci.org/mattbrictson/airbrussh)
+[![Build status](https://ci.appveyor.com/api/projects/status/h052rlq54sne3md6/branch/master?svg=true)](https://ci.appveyor.com/project/mattbrictson/airbrussh/branch/master)
 [![Code Climate](https://codeclimate.com/github/mattbrictson/airbrussh/badges/gpa.svg)](https://codeclimate.com/github/mattbrictson/airbrussh)
 [![Coverage Status](https://coveralls.io/repos/mattbrictson/airbrussh/badge.svg?branch=master)](https://coveralls.io/r/mattbrictson/airbrussh?branch=master)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: '{build}'
+
+skip_tags: true
+
+environment:
+  matrix:
+    - ruby_version: "21"
+    - ruby_version: "21-x64"
+
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - gem install bundler --no-document --conservative --version 1.10.5
+  - bundle install --retry=3
+
+test_script:
+  - bundle exec rake
+
+build: off

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -39,7 +39,7 @@ class Airbrussh::FormatterTest < Minitest::Test
     assert_output_lines(
       "      01 \e[0;33;49mecho foo\e[0m\n",
       "      01 foo\n",
-      /    \e\[0;32;49m✔ 01 #{@user}@localhost\e\[0m \e\[0;90;49m0.\d+s\e\[0m\n/
+      /    \e\[0;32;49m✔ 01 #{@user}@localhost\e\[0m \e\[0;90;49m\d.\d+s\e\[0m\n/
     )
 
     assert_log_file_lines(
@@ -62,7 +62,7 @@ class Airbrussh::FormatterTest < Minitest::Test
     assert_output_lines(
       "      01 echo foo\n",
       "      01 foo\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/
+      /    ✔ 01 #{@user}@localhost \d.\d+s\n/
     )
 
     assert_log_file_lines(
@@ -81,7 +81,7 @@ class Airbrussh::FormatterTest < Minitest::Test
 
     assert_output_lines(
       "      01 ls -l\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/
+      /    ✔ 01 #{@user}@localhost \d.\d+s\n/
     )
   end
 
@@ -108,7 +108,7 @@ class Airbrussh::FormatterTest < Minitest::Test
     expected_output = [
       "      01 \e[0;33;49mecho hi\e[0m\n",
       "      01 hi\n",
-      /    \e\[0;32;49m✔ 01 test_user@localhost\e\[0m \e\[0;90;49m0.\d+s\e\[0m\n/,
+      /    \e\[0;32;49m✔ 01 test_user@localhost\e\[0m \e\[0;90;49m\d.\d+s\e\[0m\n/,
       "      02 \e[0;33;49mnogo mr\e[0m\n"
     ]
 
@@ -151,7 +151,7 @@ class Airbrussh::FormatterTest < Minitest::Test
     assert_output_lines(
       "      01 \e[0;33;49mls -1 airbrussh.gemspec\e[0m\n",
       "      01 airbrussh.gemspec\n",
-      /    \e\[0;32;49m✔ 01 #{@user}@localhost\e\[0m \e\[0;90;49m0.\d+s\e\[0m\n/
+      /    \e\[0;32;49m✔ 01 #{@user}@localhost\e\[0m \e\[0;90;49m\d.\d+s\e\[0m\n/
     )
 
     assert_log_file_lines(
@@ -171,7 +171,7 @@ class Airbrussh::FormatterTest < Minitest::Test
     assert_output_lines(
       "      01 ls -1 airbrussh.gemspec\n",
       "      01 airbrussh.gemspec\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/
+      /    ✔ 01 #{@user}@localhost \d.\d+s\n/
     )
 
     assert_log_file_lines(
@@ -222,20 +222,20 @@ class Airbrussh::FormatterTest < Minitest::Test
       "00:00 special_rake_task\n",
       "      01 echo command 1\n",
       "      01 command 1\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
+      /    ✔ 01 #{@user}@localhost \d.\d+s\n/,
       "      Starting command 2\n",
       "      02 echo command 2\n",
       "      02 command 2\n",
-      /    ✔ 02 #{@user}@localhost 0.\d+s\n/,
+      /    ✔ 02 #{@user}@localhost \d.\d+s\n/,
       "00:00 special_rake_task_2\n",
       "      New task starting\n",
       "00:00 special_rake_task_3\n",
       "      01 echo command 3\n",
       "      01 command 3\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
+      /    ✔ 01 #{@user}@localhost \d.\d+s\n/,
       "      02 echo command 4\n",
       "      02 command 4\n",
-      /    ✔ 02 #{@user}@localhost 0.\d+s\n/,
+      /    ✔ 02 #{@user}@localhost \d.\d+s\n/,
       "      All done\n"
     )
 
@@ -301,14 +301,14 @@ class Airbrussh::FormatterTest < Minitest::Test
       "00:00 interleaving_test\n",
       "      01 echo command 1\n",
       "      01 command 1\n",
-      /    ✔ 01 #{@user}@localhost 0.\d+s\n/,
+      /    ✔ 01 #{@user}@localhost \d.\d+s\n/,
       "      Info line should be output\n",
       "      02 echo command 2\n",
       "      02 command 2\n",
-      /    ✔ 02 #{@user}@localhost 0.\d+s\n/,
+      /    ✔ 02 #{@user}@localhost \d.\d+s\n/,
       "      03 echo command 4\n",
       "      03 command 4\n",
-      /    ✔ 03 #{@user}@localhost 0.\d+s\n/
+      /    ✔ 03 #{@user}@localhost \d.\d+s\n/
     )
   end
 
@@ -368,11 +368,11 @@ class Airbrussh::FormatterTest < Minitest::Test
   end
 
   def command_success
-    /#{blue('INFO')} \[#{green('\w+')}\] Finished in 0.\d+ seconds with exit status 0 \(#{bold_green("successful")}\).\n/
+    /#{blue('INFO')} \[#{green('\w+')}\] Finished in \d.\d+ seconds with exit status 0 \(#{bold_green("successful")}\).\n/
   end
 
   def command_failed(exit_status)
-    /#{black('DEBUG')} \[#{green('\w+')}\] Finished in 0.\d+ seconds with exit status #{exit_status} \(#{bold_red("failed")}\)/
+    /#{black('DEBUG')} \[#{green('\w+')}\] Finished in \d.\d+ seconds with exit status #{exit_status} \(#{bold_red("failed")}\)/
   end
 
   {

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -198,15 +198,16 @@ class Airbrussh::FormatterTest < Minitest::Test
     end
 
     on_local do
-      test("[ -f ~ ]")
+      test("echo hi")
     end
 
     assert_output_lines
 
     assert_log_file_lines(
-      command_running("\\[ -f ~ \\]", "DEBUG"),
-      command_started_debug("\\[ -f ~ \\]"),
-      command_failed(256)
+      command_running("echo hi", "DEBUG"),
+      command_started_debug("echo hi"),
+      command_std_stream(:stdout, "hi"),
+      command_success("DEBUG")
     )
   end
 
@@ -298,10 +299,10 @@ class Airbrussh::FormatterTest < Minitest::Test
     end
 
     on_local("interleaving_test") do
-      test("[ -f ~ ]")
+      test("echo hi")
       # test methods are logged at debug level by default
       execute(:echo, "command 1")
-      test("[ -f . ]")
+      test("echo hello")
       debug("Debug line should not be output")
       info("Info line should be output")
       execute(:echo, "command 2")
@@ -381,8 +382,9 @@ class Airbrussh::FormatterTest < Minitest::Test
     /#{black('DEBUG')} \[#{green('\w+')}\] #{formatted_output}/
   end
 
-  def command_success
-    /#{blue('INFO')} \[#{green('\w+')}\] Finished in \d.\d+ seconds with exit status 0 \(#{bold_green("successful")}\).\n/
+  def command_success(level="INFO")
+    level_tag_color = (level == "INFO") ? :blue : :black
+    /#{send(level_tag_color, level)} \[#{green('\w+')}\] Finished in \d.\d+ seconds with exit status 0 \(#{bold_green("successful")}\).\n/
   end
 
   def command_failed(exit_status)

--- a/test/airbrussh/log_file_formatter_test.rb
+++ b/test/airbrussh/log_file_formatter_test.rb
@@ -1,5 +1,6 @@
 require "minitest_helper"
 require "airbrussh/log_file_formatter"
+require "fileutils"
 require "tempfile"
 
 class Airbrussh::LogFileFormatterTest < Minitest::Test
@@ -30,7 +31,7 @@ class Airbrussh::LogFileFormatterTest < Minitest::Test
   end
 
   def test_creates_log_directory_and_file
-    Dir.mktmpdir("airbrussh-test-") do |dir|
+    with_tempdir do |dir|
       log_file = File.join(dir, "log", "capistrano.log")
       Airbrussh::LogFileFormatter.new(log_file)
       assert(File.exist?(log_file))
@@ -41,5 +42,12 @@ class Airbrussh::LogFileFormatterTest < Minitest::Test
 
   def output
     @output ||= IO.read(@file.path)
+  end
+
+  def with_tempdir
+    dir = Dir.mktmpdir("airbrussh-test-")
+    yield(dir)
+  ensure
+    FileUtils.rm_rf(dir)
   end
 end


### PR DESCRIPTION
This PR makes the airbrussh tests work on Windows and sets up a Windows-based CI. The build status can be found here: https://ci.appveyor.com/project/mattbrictson/airbrussh

Getting airbrussh's tests to execute on Windows was a bit of a challenge, mainly due to the acceptance tests assuming a UNIX-like environment. I had to make the following fixes:

1. AppVeyor (the CI service) apparently does not use a pty, so `$stdout.tty?` returns false in that environment. This had the effect of disabling color in the `Pretty` log file output. I worked around this by setting `SSHKIT_COLOR=1` during the tests to force color output.
2. There is no such thing as `/usr/bin/env` on Windows, which by default SSHKit prepends to every command. To fix this, I faked the SSHKit command map to never prefix commands.
3. `Env.getpwuid` (used by `SSHKit::Host`) doesn't work on Windows. I stubbed it.
4. `[ -f ~ ]` is not understood shell syntax on Windows. I replaced it with `echo`.

All tests now pass on both Travis and AppVeyor.

@robd In your opinion have a mangled the acceptance tests with these changes? I am particularly worried that by using the `SSHKIT_COLOR=1` and command map faking that the tests have diverged slightly from the typical SSHKit configuration, and therefore the tests are now of lower quality.

Windows compatibility is not a high priority, so if the acceptance tests have been compromised as a result of my changes, perhaps it is not worth merging this. Let me know what you think.