### PR TITLE
Use "..." instead of ellipsis on UTF-8 failure.

### DIFF
--- a/lib/airbrussh/console.rb
+++ b/lib/airbrussh/console.rb
@@ -39,11 +39,12 @@ module Airbrussh
 
     def truncate_to_console_width(string)
       string = (string || "").rstrip
+      ellipsis = utf8_supported?(string) ? "…" : "..."
       width = console_width
 
       if strip_ascii_color(string).length > width
         string.chop! while strip_ascii_color(string).length >= width
-        string << "…\e[0m"
+        string << "#{ellipsis}\e[0m"
       else
         string
       end
@@ -73,6 +74,12 @@ module Airbrussh
       else
         false
       end
+    end
+
+    def utf8_supported?(string)
+      string.encode("UTF-8").valid_encoding?
+    rescue Encoding::UndefinedConversionError
+      false
     end
   end
 end

--- a/test/airbrussh/console_test.rb
+++ b/test/airbrussh/console_test.rb
@@ -79,7 +79,24 @@ class Airbrussh::ConsoleTest < Minitest::Test
     assert_equal("The quick brown fox jumps over the lazy dog.\n", output)
   end
 
+  # SSHKit sometimes returns raw ASCII-8BIT data that cannot be converted to
+  # UTF-8, which could frustrate the truncation logic. Make sure that Console
+  # recovers gracefully in this scenario.
+  def test_truncates_improperly_encoded_ascii_string
+    console = configured_console(:tty => true) do |config|
+      config.color = false
+      config.truncate = 10
+    end
+
+    console.print_line(ascii_8bit("The ‘quick’ brown fox"))
+    assert_equal(ascii_8bit("The ‘qu...\n"), ascii_8bit(output))
+  end
+
   private
+
+  def ascii_8bit(string)
+    string.force_encoding("ASCII-8BIT")
+  end
 
   def output
     @output.string


### PR DESCRIPTION
This can happen when SSHKit returns stdout/stderr data in raw ASCII-8BIT form.

@robd Does this look like a good fix for #57?