### PR TITLE
Experimental: refactor Airbrussh::Colors to be class, rather than module

### DIFF
--- a/lib/airbrussh/capistrano/tasks.rb
+++ b/lib/airbrussh/capistrano/tasks.rb
@@ -16,13 +16,13 @@ module Airbrussh
       extend Forwardable
       def_delegators :dsl, :set
       def_delegators :config, :log_file
-
-      include Airbrussh::Colors
+      def_delegators :@colors, *Airbrussh::Colors.names
 
       def initialize(dsl, stderr=$stderr, config=Airbrussh.configuration)
         @dsl = dsl
         @stderr = stderr
         @config = config
+        @colors = config.colors(stderr)
 
         configure
         warn_if_missing_dsl

--- a/lib/airbrussh/colors.rb
+++ b/lib/airbrussh/colors.rb
@@ -3,12 +3,28 @@ module Airbrussh
   # any external dependencies.
   module Colors
     ANSI_CODES = {
-      :red    => 31,
-      :green  => 32,
-      :yellow => 33,
-      :blue   => 34,
-      :gray   => 90
+      :black   => 30,
+      :red     => 31,
+      :green   => 32,
+      :yellow  => 33,
+      :blue    => 34,
+      :magenta => 35,
+      :cyan    => 36,
+      :white   => 37,
+      :gray    => 90,
+      :light_black   => 90,
+      :light_red     => 91,
+      :light_green   => 92,
+      :light_yellow  => 93,
+      :light_blue    => 94,
+      :light_magenta => 95,
+      :light_cyan    => 96,
+      :light_white   => 97
     }.freeze
+
+    def self.names
+      ANSI_CODES.keys
+    end
 
     # Define red, green, blue, etc. methods that return a copy of the
     # String that is wrapped in the corresponding ANSI color escape

--- a/lib/airbrussh/colors.rb
+++ b/lib/airbrussh/colors.rb
@@ -1,7 +1,7 @@
 module Airbrussh
   # Very basic support for ANSI color, so that we don't have to rely on
   # any external dependencies.
-  module Colors
+  class Colors
     ANSI_CODES = {
       :black   => 30,
       :red     => 31,
@@ -26,14 +26,22 @@ module Airbrussh
       ANSI_CODES.keys
     end
 
+    def initialize(enabled=true)
+      @enabled = enabled
+    end
+
+    def enabled?
+      @enabled
+    end
+
     # Define red, green, blue, etc. methods that return a copy of the
     # String that is wrapped in the corresponding ANSI color escape
     # sequence.
     ANSI_CODES.each do |name, code|
       define_method(name) do |string|
+        return string.to_s unless enabled?
         "\e[0;#{code};49m#{string}\e[0m"
       end
-      module_function(name)
     end
   end
 end

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -11,11 +11,13 @@ module Airbrussh
   #              all commands that have been run in the current rake task
   #  class CommandFormatter < SimpleDelegator
   class CommandFormatter < SimpleDelegator
-    include Airbrussh::Colors
+    extend Forwardable
+    def_delegators :@colors, :gray, :green, :red, :yellow
 
-    def initialize(command, position)
+    def initialize(command, position, colors=Airbrussh::Colors)
       super(command)
       @position = position
+      @colors = colors
     end
 
     # Prefixes the line with the command number and removes the newline.

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 require "airbrussh/colors"
-require "delegate"
+require "forwardable"
 # rubocop:disable Style/AsciiComments
 
 module Airbrussh
@@ -12,9 +12,9 @@ module Airbrussh
   #  class CommandFormatter < SimpleDelegator
   class CommandFormatter < SimpleDelegator
     extend Forwardable
-    def_delegators :@colors, :gray, :green, :red, :yellow
+    def_delegators :@colors, *Airbrussh::Colors.names
 
-    def initialize(command, position, colors=Airbrussh::Colors)
+    def initialize(command, position, colors=Airbrussh::Colors.new)
       super(command)
       @position = position
       @colors = colors

--- a/lib/airbrussh/configuration.rb
+++ b/lib/airbrussh/configuration.rb
@@ -16,15 +16,22 @@ module Airbrussh
       self.command_output = false
     end
 
-    def banner_message
+    # Returns a configured Colors object appropriate for the given io.
+    # This is based on the color setting (true, false, or :auto), and whether
+    # the io is a tty.
+    def colors(io)
+      Airbrussh::Colors.new(color?(io))
+    end
+
+    def banner_message(io)
       return nil unless banner
       return banner unless banner == :auto
-      msg = "Using airbrussh format."
+      m = "Using airbrussh format."
       if log_file
-        msg << "\n"
-        msg << "Verbose output is being written to #{Colors.blue(log_file)}."
+        m << "\n"
+        m << "Verbose output is being written to #{colors(io).blue(log_file)}."
       end
-      msg
+      m
     end
 
     # This returns an array of formatters appropriate for the configuration.
@@ -38,6 +45,19 @@ module Airbrussh
 
     def show_command_output?(sym)
       command_output == true || Array(command_output).include?(sym)
+    end
+
+    private
+
+    def color?(io)
+      case color
+      when true
+        true
+      when :auto
+        ENV["SSHKIT_COLOR"] || (io.respond_to?("tty?") && io.tty?)
+      else
+        false
+      end
     end
   end
 end

--- a/lib/airbrussh/console.rb
+++ b/lib/airbrussh/console.rb
@@ -36,7 +36,8 @@ module Airbrussh
       if strip_ascii_color(string).length > width
         width -= ellipsis.length
         string.chop! while strip_ascii_color(string).length > width
-        string << ellipsis + ("\e[0m" if contains_ascii_color?(string)).to_s
+        string << ellipsis
+        terminate_color(string)
       else
         string
       end
@@ -44,10 +45,6 @@ module Airbrussh
 
     def strip_ascii_color(string)
       (string || "").gsub(/\033\[[0-9;]*m/, "")
-    end
-
-    def contains_ascii_color?(string)
-      string =~ /\033\[[0-9;]*m/
     end
 
     def console_width
@@ -60,6 +57,14 @@ module Airbrussh
     end
 
     private
+
+    def terminate_color(string)
+      string << ("\e[0m" if contains_ascii_color?(string)).to_s
+    end
+
+    def contains_ascii_color?(string)
+      string =~ /\033\[[0-9;]*m/
+    end
 
     def utf8_supported?(string)
       string.encode("UTF-8").valid_encoding?

--- a/lib/airbrussh/console.rb
+++ b/lib/airbrussh/console.rb
@@ -4,6 +4,10 @@ require "io/console"
 module Airbrussh
   # Helper class that wraps an IO object and provides methods for truncating
   # output, assuming the IO object represents a console window.
+  #
+  # If color is disabled for the IO object (based on Airbrussh::Configuration),
+  # any ANSI color codes will also be stripped from the output.
+  #
   class Console
     attr_reader :output, :config
 
@@ -13,15 +17,19 @@ module Airbrussh
     end
 
     # Writes to the IO after first truncating the output to fit the console
-    # width. A newline is always added.
+    # width. If color is disabled for the underlying IO, ANSI colors are also
+    # removed from the output. A newline is always added.
     def print_line(obj="")
       string = obj.to_s
+
       string = truncate_to_console_width(string) if console_width
+      string = strip_ascii_color(string) unless color_enabled?
+
       write(string + "\n")
       output.flush
     end
 
-    # Writes directly through to the IO with no truncation logic.
+    # Writes directly through to the IO with no truncation or color logic.
     # No newline is added.
     def write(string)
       output.write(string || "")
@@ -36,8 +44,7 @@ module Airbrussh
       if strip_ascii_color(string).length > width
         width -= ellipsis.length
         string.chop! while strip_ascii_color(string).length > width
-        string << ellipsis
-        terminate_color(string)
+        string << "#{ellipsis}\e[0m"
       else
         string
       end
@@ -58,12 +65,8 @@ module Airbrussh
 
     private
 
-    def terminate_color(string)
-      string << ("\e[0m" if contains_ascii_color?(string)).to_s
-    end
-
-    def contains_ascii_color?(string)
-      string =~ /\033\[[0-9;]*m/
+    def color_enabled?
+      @color_enabled ||= config.colors(output).enabled?
     end
 
     def utf8_supported?(string)

--- a/test/airbrussh/colors_test.rb
+++ b/test/airbrussh/colors_test.rb
@@ -1,26 +1,64 @@
 require "minitest_helper"
 require "airbrussh/colors"
+require "forwardable"
 
 class Airbrussh::ColorsTest < Minitest::Test
-  include Airbrussh::Colors
+  extend Forwardable
+  def_delegators :@colors, *Airbrussh::Colors.names
 
   def test_red
+    enable_color
     assert_equal("\e[0;31;49mhello\e[0m", red("hello"))
   end
 
   def test_green
+    enable_color
     assert_equal("\e[0;32;49mhello\e[0m", green("hello"))
   end
 
   def test_yellow
+    enable_color
     assert_equal("\e[0;33;49mhello\e[0m", yellow("hello"))
   end
 
   def test_blue
+    enable_color
     assert_equal("\e[0;34;49mhello\e[0m", blue("hello"))
   end
 
   def test_gray
+    enable_color
     assert_equal("\e[0;90;49mhello\e[0m", gray("hello"))
+  end
+
+  def test_red_disabled
+    enable_color(false)
+    assert_equal("hello", red("hello"))
+  end
+
+  def test_green_disabled
+    enable_color(false)
+    assert_equal("hello", green("hello"))
+  end
+
+  def test_yellow_disabled
+    enable_color(false)
+    assert_equal("hello", yellow("hello"))
+  end
+
+  def test_blue_disabled
+    enable_color(false)
+    assert_equal("hello", blue("hello"))
+  end
+
+  def test_gray_disabled
+    enable_color(false)
+    assert_equal("hello", gray("hello"))
+  end
+
+  private
+
+  def enable_color(enabled=true)
+    @colors = Airbrussh::Colors.new(enabled)
   end
 end

--- a/test/airbrussh/console_test.rb
+++ b/test/airbrussh/console_test.rb
@@ -10,6 +10,47 @@ class Airbrussh::ConsoleTest < Minitest::Test
     @output = StringIO.new
   end
 
+  def test_color_is_allowed_for_tty
+    console = configured_console(:tty => true) do |config|
+      config.color = :auto
+    end
+    console.print_line("The \e[0;32;49mgreen\e[0m text")
+    assert_equal("The \e[0;32;49mgreen\e[0m text\n", output)
+  end
+
+  def test_color_is_can_be_forced
+    console = configured_console(:tty => false) do |config|
+      config.color = true
+    end
+    console.print_line("The \e[0;32;49mgreen\e[0m text")
+    assert_equal("The \e[0;32;49mgreen\e[0m text\n", output)
+  end
+
+  def test_color_is_can_be_forced_via_env
+    console = configured_console(:tty => false) do |config|
+      config.color = :auto
+    end
+    ENV.stubs(:[]).with("SSHKIT_COLOR").returns("1")
+    console.print_line("The \e[0;32;49mgreen\e[0m text")
+    assert_equal("The \e[0;32;49mgreen\e[0m text\n", output)
+  end
+
+  def test_color_is_stripped_for_non_tty
+    console = configured_console(:tty => false) do |config|
+      config.color = :auto
+    end
+    console.print_line("The \e[0;32;49mgreen\e[0m text")
+    assert_equal("The green text\n", output)
+  end
+
+  def test_color_can_be_disabled_for_tty
+    console = configured_console(:tty => true) do |config|
+      config.color = false
+    end
+    console.print_line("The \e[0;32;49mgreen\e[0m text")
+    assert_equal("The green text\n", output)
+  end
+
   def test_truncates_to_winsize
     console = configured_console(:tty => true) do |config|
       config.color = false

--- a/test/airbrussh/console_test.rb
+++ b/test/airbrussh/console_test.rb
@@ -10,47 +10,6 @@ class Airbrussh::ConsoleTest < Minitest::Test
     @output = StringIO.new
   end
 
-  def test_color_is_allowed_for_tty
-    console = configured_console(:tty => true) do |config|
-      config.color = :auto
-    end
-    console.print_line("The \e[0;32;49mgreen\e[0m text")
-    assert_equal("The \e[0;32;49mgreen\e[0m text\n", output)
-  end
-
-  def test_color_is_can_be_forced
-    console = configured_console(:tty => false) do |config|
-      config.color = true
-    end
-    console.print_line("The \e[0;32;49mgreen\e[0m text")
-    assert_equal("The \e[0;32;49mgreen\e[0m text\n", output)
-  end
-
-  def test_color_is_can_be_forced_via_env
-    console = configured_console(:tty => false) do |config|
-      config.color = :auto
-    end
-    ENV.stubs(:[]).with("SSHKIT_COLOR").returns("1")
-    console.print_line("The \e[0;32;49mgreen\e[0m text")
-    assert_equal("The \e[0;32;49mgreen\e[0m text\n", output)
-  end
-
-  def test_color_is_stripped_for_non_tty
-    console = configured_console(:tty => false) do |config|
-      config.color = :auto
-    end
-    console.print_line("The \e[0;32;49mgreen\e[0m text")
-    assert_equal("The green text\n", output)
-  end
-
-  def test_color_can_be_disabled_for_tty
-    console = configured_console(:tty => true) do |config|
-      config.color = false
-    end
-    console.print_line("The \e[0;32;49mgreen\e[0m text")
-    assert_equal("The green text\n", output)
-  end
-
   def test_truncates_to_winsize
     console = configured_console(:tty => true) do |config|
       config.color = false


### PR DESCRIPTION
This refactor more closely aligns `Airbrussh::Colors` with `SSHKit::Color`. Now they are both classes and their colorization behavior is toggled based on a flag (which is determined using `:tty?`).

This will bring us closer to consolidating the colors implementation across projects.

What do you think of this so far, @robd ?