### PR TITLE
Fall back to ssh_options[:user] if host.user.nil?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Airbrussh is in a pre-1.0 state. This means that its APIs and behavior are subje
 ## [Unreleased]
 
 * Your contribution here!
+* Airbrussh now displays the correct user@host output in the following edge-cases:
+    * Inside an SSHKit `as(:user => "...")` block
+    * When a user is specified using `set :ssh_options, :user => "..."` ([see #65](https://github.com/mattbrictson/airbrussh/issues/65))
 
 ## [0.7.0][] (2015-08-08)
 

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -58,9 +58,9 @@ module Airbrussh
     private
 
     def user_at_host
-      user_str = user { host.user }
-      host_str = host.to_s
-      [user_str, host_str].join("@")
+      user_str = host.user || (host.ssh_options || {})[:user]
+      host_str = host.hostname
+      [user_str, host_str].compact.join("@")
     end
 
     def runtime


### PR DESCRIPTION
Up until now Airbrussh has displayed the username using `host.name`. However, this may be `nil` in favor of using `ssh_options[:user]`. Use the SSH options in this case.

If for some reason no user is specified with either method, then omit the `@` symbol and just print the hostname instead of `@hostname`.

Addresses #65.

@felixbuenemann does this look good to you?
/cc @robd 