### PR TITLE
Gracefully handle nil position bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. This projec
 ## [Unreleased]
 
 * Your contribution here!
+* Fix a crash that can happen in certain multi-server deployments when
+  Capistrano's `invoke` is used to switch Rake tasks in the middle of SSHKit
+  execution ([#78](https://github.com/mattbrictson/airbrussh/issues/78),
+  [#80](https://github.com/mattbrictson/airbrussh/pull/80))
 
 ## [1.0.1][] (2016-03-21)
 

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -8,8 +8,8 @@ module Airbrussh
   # command's position within currently executing rake task:
   #
   # * position - zero-based position of this command in the list of
-  #              all commands that have been run in the current rake task
-  #  class CommandFormatter < SimpleDelegator
+  #              all commands that have been run in the current rake task; in
+  #              some cases this could be nil
   class CommandFormatter < SimpleDelegator
     include Airbrussh::Colors
 
@@ -72,7 +72,7 @@ module Airbrussh
     end
 
     def number
-      format("%02d", @position + 1)
+      format("%02d", @position.to_i + 1)
     end
 
     def success_message

--- a/lib/airbrussh/rake/context.rb
+++ b/lib/airbrussh/rake/context.rb
@@ -8,6 +8,12 @@ module Airbrussh
     # which can be disabled via by setting
     # Airbrussh.configuration.monkey_patch_rake = false.
     #
+    # Note that this class is not thread-safe. Normally this is not a problem,
+    # but some Capistrano users are known to use `invoke` to switch the Rake
+    # task in the middle of an SSHKit thread, which causes Context to get very
+    # confused. It such scenarios Context is not reliable and may return `nil`
+    # for the `position` of a command.
+    #
     class Context
       def initialize(config=Airbrussh.configuration)
         @history = []
@@ -37,7 +43,8 @@ module Airbrussh
         first_execution
       end
 
-      # The position of the specified command in the current rake task
+      # The zero-based position of the specified command in the current rake
+      # task. May be `nil` in certain multi-threaded scenarios, so be careful!
       def position(command)
         history.index(command.to_s)
       end

--- a/test/airbrussh/command_formatter_test.rb
+++ b/test/airbrussh/command_formatter_test.rb
@@ -58,6 +58,11 @@ class Airbrussh::CommandFormatterTest < Minitest::Test
     )
   end
 
+  def test_handles_nil_position_gracefully
+    command = Airbrussh::CommandFormatter.new(@sshkit_command, nil)
+    assert_equal("01 hello", command.format_output("hello\n"))
+  end
+
   private
 
   def host(user, hostname, ssh_options={})


### PR DESCRIPTION
Airbrussh::Rake::Context is not thread-safe, and this can cause problems in some Capistrano deployments. For now, work around the problem by defaulting to "01" for the command number in Airbrussh's output when Context is not able to provide the correct info.

Fixes #78 