### PR TITLE
Fix Travis for Ruby 1.9.3 by pinning json gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,8 @@ if (sshkit_version = ENV["sshkit"])
   gem "sshkit", requirement
 end
 
+# json 2.0+ is not compatible with Ruby 1.9, so pin at older version.
+gem "json", "~> 1.8" if RUBY_VERSION == "1.9.3"
+
 # net-ssh 3.0+ is not compatible with Ruby 1.9, so pin at older version.
 gem "net-ssh", "~> 2.8" if RUBY_VERSION == "1.9.3"


### PR DESCRIPTION
Because the latest json gem dropped support for Ruby 1.9.