### PR TITLE
Ensure deploy failure output is *not* truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. This projec
 ## [Unreleased]
 
 * Your contribution here!
+* When a Capistrano deploy fails and the error log is dumped to the console,
+  Airbrussh no longer truncates the error output. This ensures that important
+  troubleshooting information is not lost.
+  [#91](https://github.com/mattbrictson/airbrussh/issues/91)
 
 ## [1.1.0][] (2016-07-26)
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,6 @@ gem "json", "~> 1.8" if RUBY_VERSION == "1.9.3"
 
 # net-ssh 3.0+ is not compatible with Ruby 1.9, so pin at older version.
 gem "net-ssh", "~> 2.8" if RUBY_VERSION == "1.9.3"
+
+# tins 1.7.0+ is not compatible with Ruby 1.9, so pin at older version.
+gem "tins", "~> 1.6.0" if RUBY_VERSION == "1.9.3"

--- a/lib/airbrussh/capistrano/tasks.rb
+++ b/lib/airbrussh/capistrano/tasks.rb
@@ -71,7 +71,12 @@ module Airbrussh
       end
 
       def err_console
-        @err_console ||= Airbrussh::Console.new(stderr)
+        @err_console ||= begin
+          # Ensure we do not truncate the error output
+          err_config = config.dup
+          err_config.truncate = false
+          Airbrussh::Console.new(stderr, err_config)
+        end
       end
 
       def error_line(line="\n")


### PR DESCRIPTION
Fixes #91 