### PR TITLE
add Label to LogMessage and colorize it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [Unreleased]
 
+* colorize LogMessage label on WARN level and above ([@klyonrad](https://github.com/klyonrad))
 * Your contribution here!
 
 ## [1.1.2][] (2017-01-02)

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -69,7 +69,20 @@ module Airbrussh
     def write_log_message(log_message)
       return if debug?(log_message)
       print_task_if_changed
-      print_indented_line(log_message.to_s)
+      print_indented_line(format_log_message(log_message))
+    end
+
+    def format_log_message(log_message)
+      case log_message.verbosity
+      when SSHKit::Logger::WARN
+        "#{yellow('WARN')}  #{log_message}"
+      when SSHKit::Logger::ERROR
+        "#{red('ERROR')} #{log_message}"
+      when SSHKit::Logger::FATAL
+        "#{red('FATAL')} #{log_message}"
+      else
+        log_message.to_s
+      end
     end
 
     # For SSHKit versions up to and including 1.7.1, the stdout and stderr

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -245,7 +245,7 @@ class Airbrussh::FormatterTest < Minitest::Test
       "      02 command 2\n",
       /    ✔ 02 #{@user_at_localhost} \d.\d+s\n/,
       "00:00 special_rake_task_2\n",
-      "      #{red('ERROR')} New task starting\n",
+      "      ERROR New task starting\n",
       "00:00 special_rake_task_3\n",
       "      01 echo command 3\n",
       "      01 command 3\n",
@@ -253,7 +253,7 @@ class Airbrussh::FormatterTest < Minitest::Test
       "      02 echo command 4\n",
       "      02 command 4\n",
       /    ✔ 02 #{@user_at_localhost} \d.\d+s\n/,
-      "      #{red('WARN')}  All done\n"
+      "      WARN  All done\n"
     )
 
     assert_log_file_lines(
@@ -268,7 +268,8 @@ class Airbrussh::FormatterTest < Minitest::Test
   end
 
   def test_log_message_levels
-    configure do |_airbrussh_config, sshkit_config|
+    configure do |airbrussh_config, sshkit_config|
+      airbrussh_config.color = true
       sshkit_config.output_verbosity = Logger::DEBUG
     end
 
@@ -280,9 +281,9 @@ class Airbrussh::FormatterTest < Minitest::Test
 
     assert_output_lines(
       "      Test\n",
-      "      #{red('FATAL')} Test\n",
-      "      #{red('ERROR')} Test\n",
-      "      #{yellow('WARN')}  Test\n",
+      "      \e[0;31;49mFATAL\e[0m Test\n",
+      "      \e[0;31;49mERROR\e[0m Test\n",
+      "      \e[0;33;49mWARN\e[0m  Test\n",
       "      Test\n"
     )
 

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -245,7 +245,7 @@ class Airbrussh::FormatterTest < Minitest::Test
       "      02 command 2\n",
       /    ✔ 02 #{@user_at_localhost} \d.\d+s\n/,
       "00:00 special_rake_task_2\n",
-      "      New task starting\n",
+      "      #{red('ERROR')} New task starting\n",
       "00:00 special_rake_task_3\n",
       "      01 echo command 3\n",
       "      01 command 3\n",
@@ -253,7 +253,7 @@ class Airbrussh::FormatterTest < Minitest::Test
       "      02 echo command 4\n",
       "      02 command 4\n",
       /    ✔ 02 #{@user_at_localhost} \d.\d+s\n/,
-      "      All done\n"
+      "      #{red('WARN')}  All done\n"
     )
 
     assert_log_file_lines(
@@ -280,9 +280,9 @@ class Airbrussh::FormatterTest < Minitest::Test
 
     assert_output_lines(
       "      Test\n",
-      "      Test\n",
-      "      Test\n",
-      "      Test\n",
+      "      #{red('FATAL')} Test\n",
+      "      #{red('ERROR')} Test\n",
+      "      #{yellow('WARN')}  Test\n",
       "      Test\n"
     )
 


### PR DESCRIPTION
This adds the level of the LogMessage as uppercase label and colorizes it when the level is WARN and above.

Inspired by the `:pretty` formatter

Closes #94 
