### PR TITLE
Fix deprecations and Travis suite for Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,21 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4.0
 env:
   - sshkit="master"
   - sshkit="= 1.7.1"
   - sshkit="= 1.6.1"
 matrix:
+  exclude:
+    # Older versions of SSHKit don't work with Ruby 2.4, so skip those
+    - rvm: 2.4.0
+      env: sshkit="= 1.7.1"
+    - rvm: 2.4.0
+      env: sshkit="= 1.6.1"
   include:
-    # Run Danger only once, on 2.3.1
-    - rvm: 2.3.1
-      before_script: bundle exec danger
+    # Run Danger only once, on 2.4.0
+    - rvm: 2.4.0
+      script: bundle exec danger
 
 before_install: gem install bundler --conservative --version '~> 1.10'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 ## [Unreleased]
 
 * Your contribution here!
+* Add Ruby 2.4.0 to testing matrix and fix Ruby 2.4 deprecation warnings
 
 ## [1.1.1][] (2016-09-09)
 

--- a/bin/test_all.rb
+++ b/bin/test_all.rb
@@ -2,7 +2,11 @@
 require "yaml"
 require "English"
 
+ruby24 = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
+
 YAML.load_file(".travis.yml")["env"].each do |sshkit_version|
+  # Older versions of SSHKit don't work with Ruby 2.4, so skip those
+  next if ruby24 && sshkit_version !~ /master/
   puts "\e[0;34;49m== Running tests against #{sshkit_version} ==\e[0m"
   output = `#{sshkit_version} bundle update`
   raise "bundle update failed: #{output}" unless $CHILD_STATUS.success?

--- a/lib/airbrussh/console.rb
+++ b/lib/airbrussh/console.rb
@@ -59,7 +59,7 @@ module Airbrussh
       width = case (truncate = config.truncate)
               when :auto
                 IO.console.winsize.last if @output.tty?
-              when Fixnum
+              when Integer
                 truncate
               end
 


### PR DESCRIPTION
Versions of SSHKit < 1.11 are not compatible with Ruby 2.4+, so skip those combinations in the Travis matrix.

Fixes #99.