### PR TITLE
Upgrade Windows build to Ruby 2.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ skip_tags: true
 
 environment:
   matrix:
-    - ruby_version: "21"
-    - ruby_version: "21-x64"
+    - ruby_version: "23"
+    - ruby_version: "23-x64"
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%


### PR DESCRIPTION
This fixes #101, where net-ssh 4.0.0 was breaking the build due to an incompatibility with Ruby 2.1 on Windows.