### PR TITLE
Upgrade development gems; fix Ruby warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 ## [Unreleased]
 
 * colorize LogMessage label on WARN level and above ([@klyonrad](https://github.com/klyonrad))
+* [#106](https://github.com/mattbrictson/airbrussh/pull/106): Remove the `log_file` parameter from the `CommandFormatter#exit_message` method; it was unused - [@mattbrictson](https://github.com/mattbrictson)
 * Your contribution here!
 
 ## [1.1.2][] (2017-01-02)

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :extras, :optional => true do
 end
 
 # Danger is used by Travis, but only for Ruby 2.0+
-gem "danger" unless RUBY_VERSION == "1.9.3"
+gem "danger", "~> 4.3" unless RUBY_VERSION == "1.9.3"
 
 if (sshkit_version = ENV["sshkit"])
   requirement = begin

--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -24,11 +24,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sshkit", [">= 1.6.1", "!= 1.7.0"]
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "rainbow", "~> 2.1.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "minitest-reporters"
-  spec.add_development_dependency "mocha"
+  spec.add_development_dependency "coveralls", "~> 0.8.15"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "minitest", "~> 5.10"
+  spec.add_development_dependency "minitest-reporters", "~> 1.1"
+  spec.add_development_dependency "mocha", "~> 1.2"
   spec.add_development_dependency "rubocop", "~> 0.41.2"
 end

--- a/lib/airbrussh/command_formatter.rb
+++ b/lib/airbrussh/command_formatter.rb
@@ -40,15 +40,9 @@ module Airbrussh
     # exit_message # => "✔ 01 user@host 0.084s"
     # exit_message # => "✘ 01 user@host 0.084s"
     #
-    # If `log_file` is specified, it is appended to the message
-    # in the failure case.
-    #
-    # exit_message("out.log")
-    # # => "✘ 01 user@host (see out.log for details) 0.084s"
-    #
-    def exit_message(log_file=nil)
+    def exit_message
       message = if failure?
-                  red(failure_message(log_file))
+                  red(failure_message)
                 else
                   green(success_message)
                 end
@@ -79,10 +73,8 @@ module Airbrussh
       "✔ #{number} #{user_at_host}"
     end
 
-    def failure_message(log_file)
-      message = "✘ #{number} #{user_at_host}"
-      message << " (see #{log_file} for details)" if log_file
-      message
+    def failure_message
+      "✘ #{number} #{user_at_host}"
     end
   end
 end

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -46,7 +46,7 @@ module Airbrussh
     def log_command_exit(command)
       return if debug?(command)
       command = decorate(command)
-      print_indented_line(command.exit_message(@log_file), -2)
+      print_indented_line(command.exit_message, -2)
     end
 
     def write(obj)

--- a/test/airbrussh/capistrano/tasks_test.rb
+++ b/test/airbrussh/capistrano/tasks_test.rb
@@ -33,8 +33,8 @@ class Airbrussh::Capistrano::TasksTest < Minitest::Test
   end
 
   def setup
-    @dsl = DSL.new(Airbrussh::Formatter.new(StringIO.new, @config))
     @config = Airbrussh::Configuration.new
+    @dsl = DSL.new(Airbrussh::Formatter.new(StringIO.new, @config))
     @stderr = StringIO.new
     @tasks = Airbrussh::Capistrano::Tasks.new(@dsl, @stderr, @config)
   end

--- a/test/airbrussh/command_formatter_test.rb
+++ b/test/airbrussh/command_formatter_test.rb
@@ -35,9 +35,9 @@ class Airbrussh::CommandFormatterTest < Minitest::Test
   def test_exit_message_failure
     @command.stub(:failure?, true) do
       assert_equal(
-        "\e[0;31;49m✘ 01 deployer@12.34.56.78 (see out.log for details)\e[0m "\
+        "\e[0;31;49m✘ 01 deployer@12.34.56.78\e[0m "\
         "1.235s",
-        @command.exit_message("out.log")
+        @command.exit_message
       )
     end
   end

--- a/test/airbrussh/console_test.rb
+++ b/test/airbrussh/console_test.rb
@@ -61,6 +61,17 @@ class Airbrussh::ConsoleTest < Minitest::Test
     assert_equal("The quick brown fox…\n", output)
   end
 
+  def test_ignores_ascii_color_codes_when_determing_truncation_amount
+    console = configured_console(:tty => true) do |config|
+      config.color = true
+      config.truncate = :auto
+    end
+    IO.stubs(:console => stub(:winsize => [100, 20]))
+    twenty_chars_plus_color = "\e[0;31;49m#{'a' * 20}\e[0m"
+    console.print_line(twenty_chars_plus_color)
+    assert_equal("#{twenty_chars_plus_color}\n", output)
+  end
+
   def test_truncates_to_explicit_width
     console = configured_console(:tty => true) do |config|
       config.color = false


### PR DESCRIPTION
This is a "spring cleaning" PR:

* Pin our development dependencies using `~>` where it makes sense
* ~~Pin RuboCop to a specific version since it is fairly volatile~~
* ~~Apply RuboCop auto-corrections based on the new 0.48.1 ruleset~~
* Upgrade to Rake 12
* Fix Ruby warnings for unused variables
* Remove `log_file` argument from `CommandFormatter#exit_message` that was never used