### PR TITLE
Add configurable task prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 ## [Unreleased]
 
 * Your contribution here!
+* [#109](https://github.com/mattbrictson/airbrussh/pull/109): Add configurable task prefix - [@gondalez](https://github.com/gondalez)
 
 ## [1.2.0][] (2017-04-14)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Here are the options you can use, and their effects (note that the defaults may 
 |`command_output`|`true`|Set to `:stdout`, `:stderr`, or `true` to display the SSH output received via stdout, stderr, or both, respectively. Set to `false` to not show any SSH output, for a minimal look.|
 |`log_file`|`log/capistrano.log`|Capistrano's verbose output is saved to this file to facilitate debugging. Set to `nil` to disable completely.|
 |`truncate`|`:auto`|Set to a number (e.g. 80) to truncate the width of the output to that many characters, or `false` to disable truncation. If `:auto`, output is automatically truncated to the width of the terminal window, if it can be determined.|
+|`task_prefix`|`nil`|A string to prefix to task output. Handy for output collapsing like [buildkite](https://buildkite.com/docs/builds/managing-log-output)'s `---` prefix|
 
 ## FAQ
 

--- a/lib/airbrussh/configuration.rb
+++ b/lib/airbrussh/configuration.rb
@@ -5,7 +5,7 @@ require "airbrussh/log_file_formatter"
 module Airbrussh
   class Configuration
     attr_accessor :log_file, :monkey_patch_rake, :color, :truncate, :banner,
-                  :command_output
+                  :command_output, :task_prefix
 
     def initialize
       self.log_file = nil
@@ -14,6 +14,7 @@ module Airbrussh
       self.truncate = :auto
       self.banner = :auto
       self.command_output = false
+      self.task_prefix = nil
     end
 
     def apply_options(options)

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -100,7 +100,7 @@ module Airbrussh
       return if current_task_name == last_printed_task
 
       self.last_printed_task = current_task_name
-      print_line("#{clock} #{blue(current_task_name)}")
+      print_line("#{config.task_prefix}#{clock} #{blue(current_task_name)}")
     end
 
     def clock

--- a/test/airbrussh/configuration_test.rb
+++ b/test/airbrussh/configuration_test.rb
@@ -13,6 +13,7 @@ class Airbrussh::ConfigurationTest < Minitest::Test
     assert_equal(:auto, @config.color)
     assert_equal(:auto, @config.truncate)
     assert_equal(:auto, @config.banner)
+    assert_nil(@config.task_prefix)
     refute(@config.monkey_patch_rake)
     refute(@config.command_output)
   end

--- a/test/airbrussh/formatter_test.rb
+++ b/test/airbrussh/formatter_test.rb
@@ -330,6 +330,26 @@ class Airbrussh::FormatterTest < Minitest::Test
     )
   end
 
+  def test_task_prefix
+    configure do |airbrussh_config|
+      airbrussh_config.monkey_patch_rake = true
+      airbrussh_config.task_prefix = "--- "
+    end
+
+    on_local("task_prefix_test") do
+      execute(:echo, "command 1")
+      execute(:echo, "command 2")
+    end
+
+    assert_output_lines(
+      "--- 00:00 task_prefix_test\n",
+      "      01 echo command 1\n",
+      /    ✔ 01 #{@user_at_localhost} \d.\d+s\n/,
+      "      02 echo command 2\n",
+      /    ✔ 02 #{@user_at_localhost} \d.\d+s\n/
+    )
+  end
+
   private
 
   def on_local(task_name=nil, &block)


### PR DESCRIPTION
`set :format_options, task_prefix: '--- '`

![image](https://cloud.githubusercontent.com/assets/1468141/26668343/e37dd04a-46db-11e7-9bf6-5cd12b0ee6cf.png)

Very handy for buildkite's [output collapsing](https://buildkite.com/docs/builds/managing-log-output) :)

![image](https://cloud.githubusercontent.com/assets/1468141/26670034/9fe56ea4-46e2-11e7-8374-b7ff0e2c03f8.png)
