### PR TITLE
log_file_formatter tests if log file already exists & refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. This projec
 
 * Your contribution here!
 
+* Add error message if log cannot be created because the required
+  directory name has been taken by a file of the same name.
+  [#115](https://github.com/mattbrictson/airbrussh/pull/115)
+
 ## [1.3.0][] (2017-06-16)
 
 * [#109](https://github.com/mattbrictson/airbrussh/pull/109): Add configurable task prefix - [@gondalez](https://github.com/gondalez)

--- a/test/airbrussh/log_file_formatter_test.rb
+++ b/test/airbrussh/log_file_formatter_test.rb
@@ -30,11 +30,20 @@ class Airbrussh::LogFileFormatterTest < Minitest::Test
     assert_match(/INFO.*hello/, output)
   end
 
+  def test_errors_if_log_directory_cannot_be_created
+    with_tempdir do |dir|
+      FileUtils.touch(File.dirname(log_file_path(dir)))
+      err = assert_raises(IOError) do
+        Airbrussh::LogFileFormatter.new(log_file_path(dir))
+      end
+      assert_match(/log is already a file/, err.message)
+    end
+  end
+
   def test_creates_log_directory_and_file
     with_tempdir do |dir|
-      log_file = File.join(dir, "log", "capistrano.log")
-      Airbrussh::LogFileFormatter.new(log_file)
-      assert(File.exist?(log_file))
+      Airbrussh::LogFileFormatter.new(log_file_path(dir))
+      assert(File.exist?(log_file_path(dir)))
     end
   end
 
@@ -42,6 +51,10 @@ class Airbrussh::LogFileFormatterTest < Minitest::Test
 
   def output
     @output ||= IO.read(@file.path)
+  end
+
+  def log_file_path(dir)
+    File.join(dir, "log", "capistrano.log")
   end
 
   def with_tempdir


### PR DESCRIPTION
- test that log directory name is available to use rather than blindly expecting it to be.
- refactoring of similar desire to present a directory for the log to use
- Fixes Vague and unhelpful error message if log cannot be created
  #97