### PR TITLE
Exclude gif and png files from built gem to significantly reduce gem byte size

### DIFF
--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/mattbrictson/airbrussh"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }.reject { |f| f.match(%r{\.(gif|png)$}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/|\.(gif|png)$}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/mattbrictson/airbrussh"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }.reject { |f| f.match(%r{\.(gif|png)$}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The current .gem file is currently ~1.38 megabytes. This is evidenced on https://rubygems.org/gems/airbrussh/versions. The bulk of the bytes is because of unnecessarily including `demo.gif` in the built gem, via the gemspec. Note that the README.md does not directly reference these files, but rather the Github-hosted copies of them, so there's no reason for them to stay in the gem. Let's save the world some network bandwidth, disk storage, and ever so slightly improve build times :).

Alternatively, you could go from a reject-list to an allow-list in the gemspec. I defaulted to the more conservative change.