### PR TITLE
Skip unsupported rubygems update on EOL rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ rvm:
   - 1.9
   - 2.0
   - 2.1
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - ruby-head
 env:
   - sshkit="master"
@@ -38,5 +38,5 @@ matrix:
       script: bundle exec danger
 
 before_install:
-  - gem update --system
+  - gem update --system || echo "skipping rubygems upgrade"
   - gem install bundler --no-document


### PR DESCRIPTION
Rubygems has dropped support for Ruby < 2.3. As a result, we can no longer run `gem update --system` on those version of Ruby.

This commit also updates the Travis config to use the latest Ruby patch versions.