### PR TITLE
Handle console output that is improperly encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 ## [Unreleased]
 
 * Your contribution here!
+* [#121](https://github.com/mattbrictson/airbrussh/pull/121): Gracefully handle SSH output that has invalid UTF-8 encoding instead of raising an exception - [@mattbrictson](https://github.com/mattbrictson)
 
 ## [1.3.1][] (2018-11-04)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,8 @@ environment:
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem install bundler --conservative --no-document -v "~>1.17"
+  - gem uninstall bundler --all --executables
+  - gem install bundler --no-document -v "~>1.17"
   - bundle install --retry=3
 
 test_script:

--- a/lib/airbrussh/console.rb
+++ b/lib/airbrussh/console.rb
@@ -53,7 +53,10 @@ module Airbrussh
     end
 
     def strip_ascii_color(string)
-      (string || "").gsub(/\033\[[0-9;]*m/, "")
+      string ||= ""
+      string = to_utf8(string) unless string.valid_encoding?
+
+      string.gsub(/\033\[[0-9;]*m/, "")
     end
 
     def console_width
@@ -84,6 +87,11 @@ module Airbrussh
       string.encode("UTF-8").valid_encoding?
     rescue Encoding::UndefinedConversionError
       false
+    end
+
+    def to_utf8(string)
+      string.force_encoding("ASCII-8BIT")
+            .encode("UTF-8", :invalid => :replace, :undef => :replace)
     end
   end
 end

--- a/test/airbrussh/console_test.rb
+++ b/test/airbrussh/console_test.rb
@@ -106,6 +106,17 @@ class Airbrussh::ConsoleTest < Minitest::Test
     assert_equal(ascii_8bit("The ‘...\n"), ascii_8bit(output))
   end
 
+  def test_print_line_handles_invalid_utf8
+    console = configured_console(:tty => false)
+
+    invalid_utf8 = "The ‘quick’ brown fox"
+                   .encode("Windows-1255")
+                   .force_encoding("UTF-8")
+
+    console.print_line(invalid_utf8)
+    assert_equal("The �quick� brown fox\n", output)
+  end
+
   def test_doesnt_truncates_to_zero_width
     console = configured_console(:tty => true) do |config|
       config.color = false


### PR DESCRIPTION
Not sure why, but in some cases the data received from SSHKit claims to be encoded as UTF-8 but is actually invalid. This causes `gsub` to blow up with `ArgumentError: invalid byte sequence in UTF-8` when airbrussh calls `strip_ascii_color`.

Work around this by detecting invalid encoding and stripping out the offending code points from string before calling `gsub`.

Fixes #120 

@dbackeus can you test using this branch to see if this resolves your issue? 🙏