### PR TITLE
Fix LoadError when airbrussh is used without rake installed

### DIFF
--- a/lib/airbrussh/rake/context.rb
+++ b/lib/airbrussh/rake/context.rb
@@ -1,5 +1,3 @@
-require "rake"
-
 module Airbrussh
   module Rake
     # Maintains information about what Rake task is currently being invoked,
@@ -53,6 +51,7 @@ module Airbrussh
         attr_accessor :current_task_name
 
         def install_monkey_patch
+          require "rake"
           return if ::Rake::Task.instance_methods.include?(:_airbrussh_execute)
 
           ::Rake::Task.class_exec do


### PR DESCRIPTION
We only actually need rake if the `monkey_patch_rake` setting is true. By default it is false, so airbrussh should be usable without rake.

However we were running `require "rake"` regardless of this config, which meant that in practice you would get a `LoadError` if rake is unavailable.

Fix by running `require "rake"` only if `monkey_patch_rake` is true.

Fixes #126