### PR TITLE
Allow ConsoleFormatter context to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Here are the options you can use, and their effects (note that the defaults may 
 |`banner`|`nil`|Provide a string (e.g. "Capistrano started!") that will be printed when Capistrano starts up.|
 |`color`|`:auto`|Use `true` or `false` to enable or disable ansi color. If set to `:auto`, Airbrussh automatically uses color based on whether the output is a TTY, or if the SSHKIT_COLOR environment variable is set.|
 |`command_output`|`true`|Set to `:stdout`, `:stderr`, or `true` to display the SSH output received via stdout, stderr, or both, respectively. Set to `false` to not show any SSH output, for a minimal look.|
+|`context`|`Airbrussh::Rake::Context`|Defines the execution context. Targeted towards uses of Airbrussh outside of Rake/Capistrano. Alternate implementations should provide the definition for `current_task_name`, `register_new_command`, and `position`.|
 |`log_file`|`log/capistrano.log`|Capistrano's verbose output is saved to this file to facilitate debugging. Set to `nil` to disable completely.|
 |`truncate`|`:auto`|Set to a number (e.g. 80) to truncate the width of the output to that many characters, or `false` to disable truncation. If `:auto`, output is automatically truncated to the width of the terminal window, if it can be determined.|
 |`task_prefix`|`nil`|A string to prefix to task output. Handy for output collapsing like [buildkite](https://buildkite.com/docs/builds/managing-log-output)'s `---` prefix|

--- a/lib/airbrussh/configuration.rb
+++ b/lib/airbrussh/configuration.rb
@@ -5,7 +5,7 @@ require "airbrussh/log_file_formatter"
 module Airbrussh
   class Configuration
     attr_accessor :log_file, :monkey_patch_rake, :color, :truncate, :banner,
-                  :command_output, :task_prefix
+                  :command_output, :task_prefix, :context
 
     def initialize
       self.log_file = nil
@@ -15,6 +15,7 @@ module Airbrussh
       self.banner = :auto
       self.command_output = false
       self.task_prefix = nil
+      self.context = Airbrussh::Rake::Context
     end
 
     def apply_options(options)

--- a/lib/airbrussh/console_formatter.rb
+++ b/lib/airbrussh/console_formatter.rb
@@ -16,7 +16,7 @@ module Airbrussh
       super(io)
 
       @config = config
-      @context = Airbrussh::Rake::Context.new(config)
+      @context = config.context.new(config)
       @console = Airbrussh::Console.new(original_output, config)
 
       write_banner

--- a/test/airbrussh/configuration_test.rb
+++ b/test/airbrussh/configuration_test.rb
@@ -16,6 +16,7 @@ class Airbrussh::ConfigurationTest < Minitest::Test
     assert_nil(@config.task_prefix)
     refute(@config.monkey_patch_rake)
     refute(@config.command_output)
+    assert_equal(Airbrussh::Rake::Context, @config.context)
   end
 
   def test_apply_options
@@ -25,7 +26,8 @@ class Airbrussh::ConfigurationTest < Minitest::Test
       :truncate => false,
       :banner => "hi",
       :monkey_patch_rake => true,
-      :command_output => true
+      :command_output => true,
+      :context => Class
     )
 
     assert_equal("test", @config.log_file)
@@ -34,6 +36,7 @@ class Airbrussh::ConfigurationTest < Minitest::Test
     assert_equal("hi", @config.banner)
     assert(@config.monkey_patch_rake)
     assert(@config.command_output)
+    assert_equal(Class, @config.context)
   end
 
   def test_apply_options_warns_on_stderr_of_bad_key


### PR DESCRIPTION
This allows for custom definitions of how context is defined for
executing commands. A passed in context class should implement the following interface:

* `current_task_name`: The currently executing task
* `register_new_command`: A new command within the current task
* `position`: The numerical position of the current command

See https://github.com/mattbrictson/airbrussh/issues/130 for more context.