### PR TITLE
Fix travis build failure with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
       env: sshkit="master"
 
 before_install:
-  - gem update --system || echo "skipping rubygems upgrade"
   - gem install bundler -v 1.17.3 --conservative --no-document
   - gem install executable-hooks --conservative --no-document
 install:


### PR DESCRIPTION
The rubygems upgrade seems to lead to a prompt like this that waits for user input, eventually timing out and failing the build:

```
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-head/bin/bundle
Overwrite the executable? [yN]
```

Fix by removing the rubygems upgrade.