### PR TITLE
Fix build failures on Ruby < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ end
 if RUBY_VERSION >= "2.1"
   # These gems need at least Ruby 2.1
   gem "coveralls", "~> 0.8.15"
+  gem "docile", "< 1.4.0"
   gem "rubocop", "0.50.0"
 
   # Optional development dependencies; requires bundler >= 1.10.


### PR DESCRIPTION
Due to:

```
In Gemfile:
  coveralls was resolved to 0.8.23, which depends on
    simplecov was resolved to 0.16.1, which depends on
      docile
```

```
Gem::RuntimeRequirementNotMetError: docile requires Ruby version >= 2.5.0.
```