### PR TITLE
Fix CI build failures due to minitest 5.19 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ executors:
         type: string
     docker:
       - image: ruby:<< parameters.version >>
+        environment:
+          MT_COMPAT: "1" # Allows old versions of mocha gem to work with minitest
 
 commands:
   bundle_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: "{build}"
 skip_tags: true
 skip_branch_with_pr: true
+environment:
+  MT_COMPAT: "1" # Allows old versions of mocha gem to work with minitest
 install:
   - set PATH=C:\Ruby26-x64\bin;%PATH%
   - bundle install --retry=3


### PR DESCRIPTION
Minitest 5.19 now requires the `MT_COMPAT` env var be explicitly set to enable the `MiniTest` naming compatibility. Old versions of the mocha gem use `MiniTest`, so this is required to run tests.

This should fix failing CI builds.