### PR TITLE
Upgrade mocha to fix test local failures against minitest 5.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ if RUBY_VERSION == "1.9.3"
   # These gems need specific version for Ruby 1.9
   gem "json", "~> 1.8"
   gem "minitest", "~> 5.11.3"
+  gem "mocha", "~> 1.2"
   gem "net-ssh", "~> 2.8"
   gem "rake", "< 12.3"
   gem "term-ansicolor", "~> 1.3.2"

--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "minitest-reporters", "~> 1.1"
-  spec.add_development_dependency "mocha", "~> 1.2"
+  spec.add_development_dependency "mocha", "~> 2.1"
 end

--- a/test/support/mocha.rb
+++ b/test/support/mocha.rb
@@ -1,4 +1,6 @@
 require "mocha/minitest"
 
-Mocha::Configuration.warn_when(:stubbing_non_existent_method)
-Mocha::Configuration.warn_when(:stubbing_non_public_method)
+Mocha.configure do |c|
+  c.stubbing_non_existent_method = :warn
+  c.stubbing_non_public_method = :warn
+end


### PR DESCRIPTION
This fixes the following test failure:

> gems/mocha-1.16.1/lib/mocha/integration/mini_test/adapter.rb:26:in 'included': uninitialized constant MiniTest (NameError)
Did you mean?  Minitest