### PR TITLE
Ensure rubocop task runs on Ruby >= 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ if RUBY_VERSION >= "2.5"
   end
 end
 
+# Needed to make rubocop 0.50.0 work on modern rubies
+gem "safe_yaml" if RUBY_VERSION >= "3.1"
+
 if (sshkit_version = ENV["sshkit"])
   requirement = begin
     Gem::Dependency.new("sshkit", sshkit_version).requirement


### PR DESCRIPTION
We use an old version of rubocop (0.50.0) in order to support code written for Ruby 1.9.3. This version of rubocop breaks on modern rubies due to changes in the YAML API.

Installing the `safe_yaml` gem is a way to work around this. If rubocop detects it, it will use the SafeYAML API instead of the one built into Ruby.