### PR TITLE
Replace minitest-reporters with minitest-rg

### DIFF
--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.10"
-  spec.add_development_dependency "minitest-reporters", "~> 1.1"
+  spec.add_development_dependency "minitest-rg", "~> 5.3"
   spec.add_development_dependency "mocha", "~> 2.1"
 end

--- a/test/support/minitest_reporters.rb
+++ b/test/support/minitest_reporters.rb
@@ -1,7 +1,0 @@
-require "minitest/reporters"
-
-Minitest::Reporters.use!(
-  Minitest::Reporters::ProgressReporter.new,
-  ENV,
-  Minitest.backtrace_filter
-)

--- a/test/support/rg.rb
+++ b/test/support/rg.rb
@@ -1,0 +1,2 @@
+# Enable color test output
+require "minitest/rg"

--- a/test/support/rg.rb
+++ b/test/support/rg.rb
@@ -1,2 +1,2 @@
 # Enable color test output
-require "minitest/rg"
+require "minitest/rg" if RUBY_VERSION >= "2.0"


### PR DESCRIPTION
Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins