### PR TITLE
Move legacy Ruby builds from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,29 +61,6 @@ jobs:
       - bundle_install:
           key: << parameters.ruby >>
       - run: bundle exec rake test
-  spec_legacy_ruby:
-    parameters:
-      ruby:
-        description: "Ruby version number"
-        default: "1.9"
-        type: string
-      sshkit:
-        description: "sshkit version number"
-        default: "1.6.1"
-        type: string
-    executor:
-      name: ruby
-      version: << parameters.ruby >>
-    steps:
-      - checkout
-      - run: |
-          echo "export sshkit=<< parameters.sshkit >>" >> $BASH_ENV
-          if [ "<< parameters.ruby >>" == "1.9" ]; then
-           echo "export RUBYOPT=-Ku" >> $BASH_ENV
-          fi
-      - bundle_install:
-          key: << parameters.ruby >>-<< parameters.sshkit >>
-      - run: bundle exec rake test
 
 workflows:
   version: 2
@@ -102,31 +79,12 @@ workflows:
                 - "3.1"
                 - "3.2"
                 - "3.3"
-      - spec_legacy_ruby:
-          matrix: &legacy_ruby_matrix
-            parameters:
-              ruby:
-                - "1.9"
-                - "2.0"
-                - "2.1"
-                - "2.2"
-                - "2.3"
-              sshkit:
-                - "1.6.1"
-                - "1.7.1"
-                - master
-            exclude:
-              - ruby: "1.9"
-                sshkit: master
   cron-workflow:
     jobs:
       - rubocop
       - spec:
           matrix:
             <<: *matrix
-      - spec_legacy_ruby:
-          matrix:
-            <<: *legacy_ruby_matrix
     triggers:
       - schedule:
           cron: "0 13 * * 6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,15 @@ jobs:
           bundler: "1.17.3"
           bundler-cache: true
       - run: bundle exec rake test
+  spec_all:
+    name: "Test / Ruby (All)"
+    runs-on: ubuntu-latest
+    needs: [spec_legacy_ruby, spec_legacy_ruby_19]
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ruby-version: "1.9"
           rubygems: "2.6.9"
+          bundler: "1.17.3"
           bundler-cache: true
       - run: bundle exec rake test
   spec_legacy_ruby:
@@ -36,5 +37,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: "1.17.3"
           bundler-cache: true
       - run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "1.9"
+          rubygems: "2.6.9"
           bundler-cache: true
       - run: bundle exec rake test
   spec_legacy_ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  spec_legacy_ruby_19:
+    name: "Test / Ruby 1.9 / SSHKit ${{ matrix.sshkit }}"
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        sshkit: ["1.6.1", "1.7.1"]
+    env:
+      sshkit: ${{ matrix.sshkit }}
+      RUBYOPT: "-Ku"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "1.9"
+          bundler-cache: true
+      - run: bundle exec rake test
+  spec_legacy_ruby:
+    name: "Test / Ruby ${{ matrix.ruby }} / SSHKit ${{ matrix.sshkit }}"
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby: ["2.0", "2.0", "2.1", "2.2", "2.3"]
+        sshkit: ["1.6.1", "1.7.1", "master"]
+    env:
+      sshkit: ${{ matrix.sshkit }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test

--- a/lib/airbrussh/console.rb
+++ b/lib/airbrussh/console.rb
@@ -62,7 +62,7 @@ module Airbrussh
     def console_width
       width = case (truncate = config.truncate)
               when :auto
-                IO.console.winsize.last if @output.tty?
+                IO.console.winsize.last if @output.tty? && IO.console
               when Integer
                 truncate
               end


### PR DESCRIPTION
For testing legacy versions of Ruby at CircleCi, we rely on the official Ruby Docker images. The `ruby:1.9` image is now so old that the latest version of the Docker Engine does not support it. As a result, CircleCI builds are now failing.

Fix this by switching from CircleCi to GitHub Actions for testing legacy Ruby versions. In the Actions workflow, we use `setup-ruby` to install the desired Ruby version, rather than rely on the problematic Docker image.