### PR TITLE
Exclude nonessential files from published gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,35 @@ rescue LoadError
   task :default => :test
 end
 
+# == "rake release" enhancements ==============================================
+
 Rake::Task["release"].enhance do
   puts "Don't forget to publish the release on GitHub!"
   system "open https://github.com/mattbrictson/airbrussh/releases"
 end
+
+task :disable_overcommit do
+  ENV["OVERCOMMIT_DISABLE"] = "1"
+end
+
+Rake::Task[:build].enhance [:disable_overcommit]
+
+task :verify_gemspec_files do
+  git_files = `git ls-files -z`.split("\x0")
+  gemspec_files = Gem::Specification.load("airbrussh.gemspec").files.sort
+  ignored_by_git = gemspec_files - git_files
+  next if ignored_by_git.empty?
+
+  raise <<~ERROR
+
+    The `spec.files` specified in airbrussh.gemspec include the following files
+    that are being ignored by git. Did you forget to add them to the repo? If
+    not, you may need to delete these files or modify the gemspec to ensure
+    that they are not included in the gem by mistake:
+
+    #{ignored_by_git.join("\n").gsub(/^/, '  ')}
+
+  ERROR
+end
+
+Rake::Task[:build].enhance [:verify_gemspec_files]

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ task :verify_gemspec_files do
   ignored_by_git = gemspec_files - git_files
   next if ignored_by_git.empty?
 
-  raise <<~ERROR
+  raise <<-ERROR.gsub(/^\s+/, "")
 
     The `spec.files` specified in airbrussh.gemspec include the following files
     that are being ignored by git. Did you forget to add them to the repo? If

--- a/airbrussh.gemspec
+++ b/airbrussh.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     "homepage_uri" => "https://github.com/mattbrictson/airbrussh"
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/|\.(gif|png)$}) }
+  spec.files         = Dir.glob(%w[LICENSE.txt README.md {exe,lib}/**/*]).reject { |f| File.directory?(f) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This PR includes two improvements:

1. Remove the use of the `git` executable from the gemspec.
2. Remove unnecessary files from the published gem, such that only `LICENSE.txt`, `README.md`, and `lib/` are included.

Fixes #158 