### PR TITLE
Update CI matrix now that sshkit has dropped Ruby < 2.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       matrix:
         ruby: ["2.0", "2.0", "2.1", "2.2", "2.3", "2.4"]
         sshkit: ["1.6.1", "1.7.1", "1.22.0"]
+        exclude:
+          - ruby: "2.4"
+            sshkit: "1.6.1"
+          - ruby: "2.4"
+            sshkit: "1.7.1"
     env:
       sshkit: ${{ matrix.sshkit }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
     env:
       sshkit: "master"
     steps:
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby: ["2.0", "2.0", "2.1", "2.2", "2.3"]
-        sshkit: ["1.6.1", "1.7.1", "master"]
+        ruby: ["2.0", "2.0", "2.1", "2.2", "2.3", "2.4"]
+        sshkit: ["1.6.1", "1.7.1", "1.22.0"]
     env:
       sshkit: ${{ matrix.sshkit }}
     steps:


### PR DESCRIPTION
Before, we were testing old versions of ruby against the master branch of sshkit, but has now dropped official support for Ruby 2.4 and older. Update the CI matrix to ensure we are using valid combinations of Ruby and sshkit versions.